### PR TITLE
Finish `ipw()` accessor work

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -98,6 +98,38 @@
   with them. Pass the modeling data to `data` to carry those columns on a frame
   that also holds the covariates the outcome formula left out.
 
+* `augment()` refuses a result whose propensity score model and outcome model
+  were fit to different rows, with an error of class
+  `propensity_augment_alignment_error`, rather than reporting one observation's
+  propensity score beside another observation's fitted value. Two models of the
+  same data most often part this way over missing values, each dropping the rows
+  a variable of its own is missing on. What is compared is the number of
+  observations each model produced an answer for and, when the outcome model's
+  frame names the exposure, the exposure values of the two model frames position
+  by position, reading a factor and the numbers its labels spell as one encoding
+  of one exposure. Exposure values that disagree prove the two models hold
+  different observations; exposure values that agree prove nothing, two different
+  sets of rows being free to carry the same sequence of values, and two encodings
+  that cannot be read onto each other, such as a factor of `"a"` and `"b"`
+  against a recoding of it as 0 and 1, prove nothing either way. The check is
+  one-sided in that direction deliberately: it refuses only what it can prove,
+  which is why a fit whose models do describe the same observations is never
+  refused, however the rows of either frame are labeled.
+
+* `augment()` refuses a frame that already holds a column it would add, with an
+  error of class `propensity_augment_column_error` naming every column that
+  clashes. Such a frame previously returned one naming the same column twice, and
+  a `.resid` column of the caller's was written over whenever the frame also held
+  the outcome to difference. The names in the way are the ones the call would
+  actually add, so `.resid` is among them only for a frame it would be added to,
+  and the propensity columns of a categorical fit are the `.propensity_<level>`
+  columns rather than `.propensity`.
+
+* `augment()` refuses a result whose outcome model was fit without weights, under
+  `propensity_ipw_weights_missing_error`, the class `ipw()` reports the same fact
+  under. An `ipw()` outcome model is weighted by construction, so `.weights` has
+  nothing to report for a result built around one that is not.
+
 * `wt_entropy()` is documented as computing entropy weights, which tilt the
   propensity score by its own entropy in the sense of Zhou, Matsouaka, and
   Thomas (2020). The package overview called them entropy balancing weights, and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,25 @@
 # propensity 0.1.0.9000 (development version)
 
+* The marginal reading of `tidy()` is now the result's own `as.data.frame()`
+  table read as a tibble rather than a second assembly of the same columns. The
+  rows, the columns, their order, and their values are the same as before, and
+  the covariance of the effects that frame attaches as an attribute is the one
+  thing the tibble does not carry, a tidied table being its columns. The
+  interval rebuilder and the confidence level validator this method kept for
+  itself go with the second assembly.
+
+* `tidy()` now refuses a bad `conf.int`, `conf.level`, or `exponentiate` under
+  the causalgenerics condition naming the argument at fault, such as
+  `causalgenerics_invalid_argument_conf.level`, rather than under a class of this
+  package's own. These are the three arguments the method shares with
+  `as.data.frame()`, which is where they are now validated, in both readings and
+  before either is assembled, so one value cannot be well formed in one reading
+  of a result and refused in the other. Code catching
+  `propensity_conf_level_error` by name needs updating. The levels `conf.level`
+  accepts are unchanged, while `conf.int` and `exponentiate` now take a single
+  `TRUE` or `FALSE` and nothing else, where a bare `if` had accepted anything it
+  could read as one.
+
 * `ipw()` gains an `effects` argument on every method, which records the reading
   the result it builds presents: `"marginal"`, the default, for the
   population-averaged causal contrasts every method reported before, or

--- a/NEWS.md
+++ b/NEWS.md
@@ -112,9 +112,10 @@
   sets of rows being free to carry the same sequence of values, and two encodings
   that cannot be read onto each other, such as a factor of `"a"` and `"b"`
   against a recoding of it as 0 and 1, prove nothing either way. The check is
-  one-sided in that direction deliberately: it refuses only what it can prove,
-  which is why a fit whose models do describe the same observations is never
-  refused, however the rows of either frame are labeled.
+  one-sided in that direction deliberately: it refuses only what it can prove, so
+  a fit whose models do describe the same observations is never refused over the
+  labels the rows of either frame carry or the encoding its exposure is written
+  in.
 
 * `augment()` refuses a frame that already holds a column it would add, with an
   error of class `propensity_augment_column_error` naming every column that

--- a/R/ipw-mestimation.R
+++ b/R/ipw-mestimation.R
@@ -2355,6 +2355,11 @@ ipw_mestimation_estimates <- function(
 # The labels every surface of a result keys its effects by: the effect measure
 # on its own, or the effect measure and the comparison together where a
 # categorical exposure reports one row per comparison.
+#
+# causalgenerics holds a function of the same name and the same rule, and the
+# duplication is deliberate: that copy labels what the accessors present, and
+# this one labels what is stored, so the block a result carries is keyed the
+# moment it is built rather than at whatever later point something reads it.
 ipw_effect_labels <- function(estimates) {
   if (is.null(estimates[["comparison"]])) {
     estimates$effect

--- a/R/ipw-tidiers.R
+++ b/R/ipw-tidiers.R
@@ -453,11 +453,12 @@ glance.ipw <- function(x, ...) {
 #' two encodings that cannot be read onto each other, such as a factor of `"a"`
 #' and `"b"` against a recoding of it as 0 and 1, prove nothing either way.
 #' The check is one-sided in that direction on purpose: it refuses only what it
-#' can prove, which is also why it never refuses a fit whose models do line up,
-#' however the rows of either are labeled. A frame
-#' that already holds a column this call would add is refused as well, because
-#' the fit's column has nowhere to go: added beside the frame's, the two would be
-#' told apart by nothing, and written over it, the frame's data would be gone.
+#' can prove, so a fit whose models do line up is never refused over the labels
+#' the rows of either frame carry or the encoding its exposure is written in. A
+#' frame that already holds a column this call would add is refused as well,
+#' because the fit's column has nowhere to go: added beside the frame's, the two
+#' would be told apart by nothing, and written over it, the frame's data would be
+#' gone.
 #' Which names are in the way depends on the fit and the frame, `.resid` being
 #' among them only for a frame it would be added to and the propensity columns
 #' being the ones the propensity score model produced. Last, a result whose
@@ -645,7 +646,8 @@ check_augment_weights <- function(weights, call = rlang::caller_env()) {
 # model frames proves they hold different observations, while an exposure that
 # agrees proves nothing, two different sets of rows being free to carry the same
 # sequence of exposure values. Refusing only what can be proven is what keeps a
-# fit whose models do line up from ever being refused.
+# fit whose models do line up from being refused over how either frame labels its
+# rows or writes its exposure down.
 check_augment_alignment <- function(
   wt_mod,
   propensity,

--- a/R/ipw-tidiers.R
+++ b/R/ipw-tidiers.R
@@ -6,11 +6,21 @@
 #' one row per effect measure per comparison for a categorical exposure, in the
 #' order the result stores them. Nothing is dropped.
 #'
-#' The values are the ones the result already holds: `tidy()` renames and
-#' selects rather than re-estimating anything. The one exception is the
-#' confidence interval, which is rebuilt from the estimate and its standard
-#' error when the requested `conf.level` differs from the level the result was
-#' fit at.
+#' Those columns are the ones the result's own coercion surface reports, so the
+#' marginal reading is [`as.data.frame()`][causalgenerics::new_ipw()] read as a
+#' tibble rather than a second assembly of the same table. The values are the
+#' ones the result already holds, nothing being re-estimated: the confidence
+#' interval is the only thing rebuilt, and only when the requested `conf.level`
+#' differs from the level the result was fit at. The one thing the frame carries
+#' that the tibble does not is the covariance of the effects it attaches as an
+#' attribute, a tidied table being its columns.
+#'
+#' `conf.int`, `conf.level`, and `exponentiate` are the arguments this method
+#' shares with that surface, so the surface validates them, in both readings and
+#' before either is assembled. A value it refuses is reported under the
+#' causalgenerics condition naming the argument at fault, which is what keeps one
+#' argument of one method from being well formed in one reading of a result and
+#' refused in the other.
 #'
 #' A result reports its effects in one of two readings, and `tidy()` returns the
 #' one the result records unless `effects` names the other for the call. The
@@ -29,7 +39,8 @@
 #'   rather than the level `x` was fit at. When the two differ, the bounds are
 #'   recomputed as the normal approximation
 #'   `estimate +/- qnorm(1 - (1 - conf.level) / 2) * std.error`, which is the
-#'   interval [ipw()] itself reports. Ignored when `conf.int` is `FALSE`.
+#'   interval [ipw()] itself reports. Not used when `conf.int` is `FALSE`, though
+#'   it must still be a valid level.
 #' @param exponentiate Logical. Should the estimate and its bounds be
 #'   exponentiated on the rows reported on the log scale? Defaults to `FALSE`.
 #'   This behaves exactly as it does in
@@ -126,7 +137,21 @@ tidy.ipw <- function(
   effects = NULL
 ) {
   rlang::check_dots_empty()
-  check_conf_level(conf.level)
+
+  # The marginal reading, which is the result's own coercion surface read as a
+  # tibble. It is built before anything branches on a reading because the three
+  # arguments the two surfaces share are validated there, and one argument of one
+  # method cannot be well formed in one reading of a result and refused in the
+  # other.
+  #
+  # The conditional reading answers from the accessors and so discards the frame,
+  # which costs a table of a few rows: nothing is refit to build it.
+  frame <- as.data.frame(
+    x,
+    conf.int = conf.int,
+    conf.level = conf.level,
+    exponentiate = exponentiate
+  )
 
   # The accessors own the `effects` argument, so the estimates of the reading
   # this call reports come from one before anything here branches on a reading.
@@ -149,51 +174,19 @@ tidy.ipw <- function(
     ))
   }
 
-  tidy_ipw_marginal(
-    x,
-    conf.int = conf.int,
-    conf.level = conf.level,
-    exponentiate = exponentiate
-  )
+  # The covariance of the effects the frame attaches is the one thing that does
+  # not travel: it is an attribute rather than a column, and a tidied table is
+  # its columns.
+  out <- tibble::as_tibble(frame)
+  attr(out, "ipw_vcov") <- NULL
+
+  out
 }
 
 # The reading a result records. A result built before the field existed carries
 # none, and marginal is the reading every method produced then.
 ipw_stored_effects <- function(x) {
   if (is.null(x$effects)) "marginal" else x$effects
-}
-
-# The marginal reading: the result's own table of causal contrasts, renamed and
-# selected into the broom columns.
-tidy_ipw_marginal <- function(x, conf.int, conf.level, exponentiate) {
-  if (conf.int) {
-    x$estimates <- recompute_ipw_interval(x$estimates, conf.level)
-  }
-
-  # Exponentiation is the result's own contract, so the coercion method applies
-  # it, to whichever interval this call settled on.
-  estimates <- as.data.frame(x, exponentiate = exponentiate)
-
-  out <- list(
-    term = estimates$effect,
-    estimate = estimates$estimate,
-    std.error = estimates$std.err,
-    statistic = estimates$z,
-    p.value = estimates$p.value
-  )
-
-  # A categorical exposure reports each effect measure once per contrast, and
-  # the column naming the contrast follows the term it qualifies.
-  if (!is.null(estimates[["comparison"]])) {
-    out <- append(out, list(comparison = estimates$comparison), after = 1L)
-  }
-
-  if (conf.int) {
-    out$conf.low <- estimates$ci.lower
-    out$conf.high <- estimates$ci.upper
-  }
-
-  tibble::as_tibble(out)
 }
 
 # The conditional reading: the outcome model's coefficient surface, in the
@@ -288,58 +281,6 @@ check_exponentiate_link <- function(outcome_mod, call = rlang::caller_env()) {
   }
 
   invisible(link)
-}
-
-# The estimates table with its interval expressed at `conf_level`. The stored
-# bounds are returned untouched when they already describe that level, so a
-# request for the level the result was fit at reports the result's own numbers
-# rather than a recomputation that merely agrees with them.
-recompute_ipw_interval <- function(estimates, conf_level) {
-  stored <- estimates[["conf.level"]]
-  if (!is.null(stored) && isTRUE(all(stored == conf_level))) {
-    return(estimates)
-  }
-
-  half_width <- stats::qnorm(1 - (1 - conf_level) / 2) * estimates$std.err
-  estimates$ci.lower <- estimates$estimate - half_width
-  estimates$ci.upper <- estimates$estimate + half_width
-  estimates$conf.level <- conf_level
-
-  estimates
-}
-
-check_conf_level <- function(
-  conf.level,
-  arg = rlang::caller_arg(conf.level),
-  call = rlang::caller_env()
-) {
-  valid <- is.numeric(conf.level) &&
-    length(conf.level) == 1L &&
-    !is.na(conf.level) &&
-    conf.level > 0 &&
-    conf.level < 1
-
-  if (!valid) {
-    # An empty value has nothing for `{.val}` to print, so it is described by
-    # its type instead.
-    supplied <- if (length(conf.level) == 0) {
-      "You supplied {.obj_type_friendly {conf.level}}."
-    } else {
-      "You supplied {.val {conf.level}}."
-    }
-
-    abort(
-      c(
-        "{.arg {arg}} must be a single number between 0 and 1.",
-        x = supplied,
-        i = "Use {.code {arg} = 0.95} for a 95% interval."
-      ),
-      error_class = "propensity_conf_level_error",
-      call = call
-    )
-  }
-
-  invisible(conf.level)
 }
 
 #' Glance at an inverse probability weighted result

--- a/R/ipw-tidiers.R
+++ b/R/ipw-tidiers.R
@@ -437,6 +437,33 @@ glance.ipw <- function(x, ...) {
 #' and is carried as it arrives, so a weight column they hold stays where they
 #' put it, whatever it is named.
 #'
+#' A column is an answer per observation only while the fit it is read from and
+#' the frame it is carried on describe the same observations, so three things are
+#' refused rather than reported. A result whose propensity score model and
+#' outcome model were fit to different rows is refused, because the propensity
+#' score of one observation would arrive beside the fitted value of another. Two
+#' models of the same data most often part this way over missing values, each
+#' dropping the rows a variable of its own is missing on. What is compared is the
+#' number of observations each model produced an answer for and, when the outcome
+#' model's frame names the exposure, the exposure values of the two model frames
+#' position by position, reading a factor and the numbers its labels spell as one
+#' encoding of one exposure. Exposure values that disagree prove the two models
+#' hold different observations; exposure values that agree prove nothing, since
+#' two different sets of rows are free to carry the same sequence of values, and
+#' two encodings that cannot be read onto each other, such as a factor of `"a"`
+#' and `"b"` against a recoding of it as 0 and 1, prove nothing either way.
+#' The check is one-sided in that direction on purpose: it refuses only what it
+#' can prove, which is also why it never refuses a fit whose models do line up,
+#' however the rows of either are labeled. A frame
+#' that already holds a column this call would add is refused as well, because
+#' the fit's column has nowhere to go: added beside the frame's, the two would be
+#' told apart by nothing, and written over it, the frame's data would be gone.
+#' Which names are in the way depends on the fit and the frame, `.resid` being
+#' among them only for a frame it would be added to and the propensity columns
+#' being the ones the propensity score model produced. Last, a result whose
+#' outcome model was fit without weights is refused under the class [ipw()]
+#' refuses the same fact with: `.weights` has nothing to report for such a fit.
+#'
 #' @param x An `ipw` object, as returned by [ipw()].
 #' @param data A data frame with one row for each observation the fit used, or
 #'   `NULL`, the default, to use the outcome model's own model frame. That frame
@@ -495,37 +522,56 @@ augment.ipw <- function(x, data = NULL, ...) {
 
   outcome_frame <- stats::model.frame(x$outcome_mod)
   weights <- stats::model.weights(outcome_frame)
+  check_augment_weights(weights)
 
-  if (is.null(data)) {
+  supplied <- !is.null(data)
+  if (supplied) {
+    assert_class(data, "data.frame")
+  } else {
     # The weights are reported as `.weights`, so the frame this method builds
     # for itself leaves out the numeric copy of them `model.frame()` records.
     # The drop belongs to this branch alone: a frame the caller supplies is
     # theirs, and a column of theirs is not deleted for matching a name.
     data <- outcome_frame[names(outcome_frame) != "(weights)"]
-  } else {
-    assert_class(data, "data.frame")
+  }
+
+  propensity <- augment_propensity_columns(x$wt_mod)
+  fitted <- unname(stats::predict(x$outcome_mod, type = "response"))
+  check_augment_alignment(x$wt_mod, propensity, fitted, outcome_frame)
+
+  if (supplied) {
     check_augment_rows(data, nrow(outcome_frame))
   }
 
-  fitted <- unname(stats::predict(x$outcome_mod, type = "response"))
+  # A residual is an observed outcome less a fitted value, so it belongs to a
+  # frame that holds the outcome and to no other.
+  response <- names(outcome_frame)[[
+    attr(stats::terms(x$outcome_mod), "response")
+  ]]
+  resid <- response %in% names(data)
+
+  # Which columns this call adds is a question about this fit and this frame:
+  # the propensity columns are the ones the propensity score model produced, and
+  # `.resid` is added only to a frame holding the outcome to difference.
+  check_augment_columns(
+    data,
+    c(names(propensity), ".weights", ".fitted", if (resid) ".resid"),
+    supplied = supplied
+  )
 
   columns <- c(
     as.list(data),
-    augment_propensity_columns(x$wt_mod),
+    propensity,
     list(
       .weights = weights,
       .fitted = fitted
     )
   )
 
-  # A residual is an observed outcome less a fitted value, so it belongs to a
-  # frame that holds the outcome and to no other. The outcome goes through the
-  # conversion the estimator itself uses, which is what puts the residual of a
-  # factor or logical outcome on the 0/1 scale its fitted values are on.
-  response <- names(outcome_frame)[[
-    attr(stats::terms(x$outcome_mod), "response")
-  ]]
-  if (response %in% names(data)) {
+  # The outcome goes through the conversion the estimator itself uses, which is
+  # what puts the residual of a factor or logical outcome on the 0/1 scale its
+  # fitted values are on.
+  if (resid) {
     columns$.resid <- ipw_outcome_numeric(data[[response]]) - fitted
   }
 
@@ -538,7 +584,8 @@ augment.ipw <- function(x, data = NULL, ...) {
 # The propensity score of each observation, as the columns it takes to hold it.
 # A binary or continuous exposure has one number per observation and so one
 # column; a categorical exposure has a probability for every level, and each
-# level gets a column of its own.
+# level gets a column of its own. A column of a tibble is addressed by its
+# position, so the observation names a prediction carries stop here.
 augment_propensity_columns <- function(wt_mod) {
   if (!inherits(wt_mod, "multinom")) {
     return(list(
@@ -563,6 +610,227 @@ augment_propensity_columns <- function(wt_mod) {
   )
 }
 
+# The outcome model of an ipw() result is fit with the estimated weights, so a
+# result reporting one that was not is a result built around something else.
+# `.weights` has nothing to report for such a fit, and the columns that remain
+# would describe an analysis the object does not name. The fact is the one
+# ipw() refuses the pair of models for, so it is reported under the class that
+# names it rather than under one naming which method noticed.
+check_augment_weights <- function(weights, call = rlang::caller_env()) {
+  if (!is.null(weights)) {
+    return(invisible(weights))
+  }
+
+  abort(
+    c(
+      "{.arg x} must hold an outcome model fit with propensity score weights.",
+      x = "The outcome model {.arg x} holds reports no weights.",
+      i = "An {.fun ipw} outcome model is weighted by construction. Refit it \\
+      with the weights the propensity score model implies, such as those \\
+      {.fun wt_ate} returns."
+    ),
+    error_class = "propensity_ipw_weights_missing_error",
+    call = call
+  )
+}
+
+# The propensity score column and the fitted values are read from two different
+# models, so they are an answer per observation only while both models describe
+# the same observations. Counts come from the fitted frames rather than from
+# `stats::nobs()`, which subtracts observations of weight zero and so would
+# report a fit that has any as shorter than the column it produces.
+#
+# What is checked beyond the counts is the exposure each model was fit to, and
+# the check is one-sided by design: an exposure that disagrees between the two
+# model frames proves they hold different observations, while an exposure that
+# agrees proves nothing, two different sets of rows being free to carry the same
+# sequence of exposure values. Refusing only what can be proven is what keeps a
+# fit whose models do line up from ever being refused.
+check_augment_alignment <- function(
+  wt_mod,
+  propensity,
+  fitted,
+  outcome_frame,
+  call = rlang::caller_env()
+) {
+  n_outcome <- nrow(outcome_frame)
+  n_fitted <- length(fitted)
+
+  # Every propensity column holds one prediction per observation, so the first
+  # of them measures them all.
+  n_propensity <- length(propensity[[1L]])
+  counted <- n_propensity == n_outcome && n_fitted == n_outcome
+
+  exposure <- if (counted) {
+    augment_mismatched_exposure(wt_mod, outcome_frame)
+  }
+
+  if (counted && is.null(exposure)) {
+    return(invisible(propensity))
+  }
+
+  # Where the counts differ they say which model produced fewer answers; where
+  # they agree it is the exposure that shows the two apart, the count saying
+  # nothing on its own.
+  problem <- if (counted) {
+    c(
+      x = "Both models were fit to {n_outcome} observation{?s}, and the \\
+      {.val {exposure}} values in the two model frames disagree."
+    )
+  } else {
+    c(
+      x = "The propensity score model produced {n_propensity} propensity \\
+      score{?s}.",
+      x = "The outcome model was fit to {n_outcome} observation{?s}."
+    )
+  }
+
+  # A model whose answers outnumber the rows it was fit to was fit under
+  # `na.action = na.exclude`, which pads a prediction back to the length of the
+  # data the model was given. That padding is the disagreement here, and the
+  # counts above do not show it.
+  if (n_fitted != n_outcome) {
+    problem <- c(
+      problem,
+      x = "The outcome model predicts {n_fitted} value{?s} for the \\
+      {n_outcome} observation{?s} it was fit to."
+    )
+  }
+
+  abort(
+    c(
+      "{.arg x} must hold two models fit to the same rows.",
+      problem,
+      i = "Two models of the same data most often part this way over missing \\
+      values, each dropping the rows a variable of its own is missing on.",
+      i = "Refit both models on the rows that are complete on every variable \\
+      either model uses."
+    ),
+    error_class = "propensity_augment_alignment_error",
+    call = call
+  )
+}
+
+# The exposure, where the two model frames can be shown to hold different
+# observations of it, and `NULL` otherwise. Both models read the exposure from
+# the same column of the same data, so a position at which the two frames record
+# different exposure values is a position at which they describe different
+# observations, whatever the row labels of either say. Row labels are not
+# compared at all: they are a record of where a row came from, so a frame
+# renumbered by the pipeline that built it carries different labels for the same
+# observations, and two frames each renumbered from one carry the same labels for
+# different ones.
+#
+# Nothing is refit and nothing is predicted: the propensity score model's own
+# model frame holds the exposure it was fit to, after the rows it dropped, and
+# the outcome model's frame holds the same variable whenever the outcome formula
+# names it. A fit that offers neither, that offers two vectors of different
+# lengths, or that records the exposure in two encodings no comparison can line
+# up, offers nothing to compare, and the counts are then all there is.
+augment_mismatched_exposure <- function(wt_mod, outcome_frame) {
+  # A response written as anything but a bare variable, such as a transformation
+  # or a two-column count, deparses to more than one name and is not a column of
+  # the outcome model's frame under any name this could look up.
+  name <- tryCatch(fmla_extract_left_chr(wt_mod), error = function(e) NULL)
+  if (length(name) != 1L || !name %in% names(outcome_frame)) {
+    return(NULL)
+  }
+
+  exposure <- tryCatch(fmla_extract_left_vctr(wt_mod), error = function(e) NULL)
+  if (is.null(exposure)) {
+    return(NULL)
+  }
+
+  from_wt_mod <- augment_exposure_values(exposure)
+  from_outcome <- augment_exposure_values(outcome_frame[[name]])
+
+  # Two vectors of different lengths cannot be compared position by position. A
+  # propensity score model fit under `na.action = na.exclude` reaches this,
+  # its predictions being padded back to the rows its frame dropped.
+  if (length(from_wt_mod) != length(from_outcome)) {
+    return(NULL)
+  }
+
+  compared <- augment_exposure_bridge(from_wt_mod, from_outcome)
+  if (is.null(compared)) {
+    return(NULL)
+  }
+
+  if (
+    isTRUE(all.equal(compared[[1L]], compared[[2L]], check.attributes = FALSE))
+  ) {
+    return(NULL)
+  }
+
+  name
+}
+
+# The exposure read down to the values it records, so that one exposure held as
+# a factor and as the labels behind it, or as integers and as the doubles of the
+# same numbers, compares equal. A factor against the numbers those labels spell
+# is a further step, taken by the bridge below. Two frames recording one
+# exposure in two representations hold the same observations of it, and a check
+# that refuses only what it can prove has to read them as such.
+augment_exposure_values <- function(x) {
+  if (is.factor(x)) {
+    return(as.character(x))
+  }
+
+  if (is.logical(x)) {
+    return(as.integer(x))
+  }
+
+  as.vector(x)
+}
+
+# One exposure recorded in two encodings, as a pair of vectors a position by
+# position comparison can be made of, or `NULL` when the two encodings cannot be
+# lined up at all. Two frames of one column usually record it the same way and
+# there is nothing to bridge. Where they do not, the case to carry is a factor
+# against the numbers it labels, which `ipw()` itself accepts: a propensity score
+# model fit to `factor(z)` and an outcome model fit to the 0/1 `z` of the same
+# data were fit to one exposure, and reading the labels as the numbers they spell
+# is what lets the two meet.
+#
+# Labels spelling something other than numbers are the other side of that case:
+# an exposure held as "a" and "b" against a recoding of it as 0 and 1 is one
+# variable written two ways that no positional comparison can line up, its values
+# differing at every position while its observations may agree at all of them.
+# Refusing there would refuse a fit whose models describe the same rows, so the
+# comparison does not apply and the counts stand alone.
+augment_exposure_bridge <- function(x, y) {
+  if (is.character(x) == is.character(y)) {
+    return(list(x, y))
+  }
+
+  if (is.character(x)) {
+    x <- augment_exposure_numbers(x)
+  } else {
+    y <- augment_exposure_numbers(y)
+  }
+
+  if (is.null(x) || is.null(y)) {
+    return(NULL)
+  }
+
+  list(x, y)
+}
+
+# Labels read as the numbers they spell, or `NULL` when any of them spells
+# something else. A label that is not a number reads as `NA`, a value the
+# exposure never held, which would then compare unequal to whatever the other
+# frame records in that position and prove a disagreement that is the encoding's
+# and not the data's.
+augment_exposure_numbers <- function(x) {
+  numbers <- suppressWarnings(as.numeric(x))
+
+  if (any(is.na(numbers) & !is.na(x))) {
+    return(NULL)
+  }
+
+  numbers
+}
+
 check_augment_rows <- function(
   data,
   n_obs,
@@ -582,6 +850,47 @@ check_augment_rows <- function(
       {.code NULL} to use the outcome model's own frame."
     ),
     error_class = "propensity_augment_data_error",
+    call = call
+  )
+}
+
+# The dot-prefixed columns are additions, so a frame already holding one of
+# their names has nowhere for the fit's own column to go: added beside the
+# frame's column, the two would be told apart by nothing, and written over it,
+# the data the frame arrived with would be gone.
+check_augment_columns <- function(
+  data,
+  added,
+  supplied,
+  call = rlang::caller_env()
+) {
+  clashing <- intersect(added, names(data))
+  if (length(clashing) == 0) {
+    return(invisible(data))
+  }
+
+  # The remedy is the frame's own: a frame the caller supplied is theirs to
+  # rename, and the frame this method builds for itself is the outcome model's,
+  # whose columns are the variables that model was fit on.
+  remedy <- if (supplied) {
+    "Rename or drop {cli::qty(clashing)}{?it/them} in {.arg data}, or leave \\
+    {.arg data} as {.code NULL} to carry the fit's columns on the outcome \\
+    model's own frame."
+  } else {
+    "The frame is the outcome model's own, so {cli::qty(clashing)}{?that name \\
+    is a variable/those names are variables} its formula reads. Rename \\
+    {?it/them} in the data the model was fit to, or supply a frame through \\
+    {.arg data}."
+  }
+
+  abort(
+    c(
+      "{.fun augment} adds {cli::qty(clashing)}{?a column/columns} the frame \\
+      carrying {?it/them} already holds.",
+      x = "The frame already holds {.val {clashing}}.",
+      i = remedy
+    ),
+    error_class = "propensity_augment_column_error",
     call = call
   )
 }

--- a/R/ipw.R
+++ b/R/ipw.R
@@ -108,7 +108,13 @@
 #'   with an intercept; a covariate-adjusted outcome model requires
 #'   `"mestimation"`. For a binary or categorical exposure, both methods require
 #'   an outcome model that can represent a baseline, so a numeric no-intercept
-#'   coding such as `y ~ z - 1` errors on either.
+#'   coding such as `y ~ z - 1` errors on either. The standard errors of the
+#'   conditional reading described under `effects` require `"mestimation"`
+#'   as well: the
+#'   linearization route stores its outcome model unwrapped, so [stats::vcov()],
+#'   [stats::confint()], and [`tidy()`][tidy.ipw()] refuse
+#'   `effects = "conditional"` there with a classed error rather than reporting
+#'   the covariance the outcome model computed for itself.
 #' @param effects The presentation mode the result records, either `"marginal"`
 #'   (the default) or `"conditional"`. The marginal reading reports the
 #'   population-averaged causal contrasts; the conditional reading reports the
@@ -173,6 +179,11 @@
 #' correct for the reversed roles, and `ipw()` rejects them rather than
 #' correcting them as though the roles matched. To target the other level,
 #' relevel the exposure so that it sorts second and refit both models.
+#'
+#' The estimand a weighted outcome model was fit for is not necessarily the one a
+#' tool that averages its per-row predictions reports, so see **Standardizing
+#' model predictions** in [ps_tilt()] before taking such an average of a model fit
+#' for anything other than `"ate"`.
 #'
 #' # Effect measures
 #'
@@ -249,6 +260,11 @@
 #' term beyond the exposure, including covariates, interactions, or transformed
 #' terms) errors on the linearization path and requires
 #' `se_method = "mestimation"`, which stacks adjusted outcome models correctly.
+#' The conditional reading is restricted the same way: linearization stacks no
+#' system, so the outcome model it stores carries no block of one, and the
+#' standard errors that reading reports are refused with a classed error rather
+#' than replaced by the covariance the outcome model computed for itself, which
+#' treats the estimated weights as fixed.
 #'
 #' The linearization outcome model must also carry an intercept, which is a
 #' stricter requirement than the M-estimation path imposes. Under a numeric

--- a/R/ps_tilt.R
+++ b/R/ps_tilt.R
@@ -48,6 +48,32 @@
 #' weight by a marginal quantity that does not depend on the covariates, and
 #' `wt_cens()` reuses the `"ate"` formula, so neither has an entry here.
 #'
+#' # Standardizing model predictions
+#'
+#' A g-computation estimate averages an outcome model's per-row counterfactual
+#' predictions, and where those predictions vary from row to row it is the
+#' weights of that average that standardize the estimate to a target population.
+#' The tilt is those weights, which is what the second example below supplies by
+#' hand. An average taken with equal weight standardizes a covariate-adjusted
+#' outcome model to the whole sample, so such a model targets the ATE however its
+#' own fitting weights were built: fit for a non-`"ate"` estimand and averaged
+#' that way, it reports the full-sample contrast rather than the one it was
+#' weighted for. Tools that average per-row model predictions, such as the
+#' `avg_comparisons()` function in the marginaleffects package, average with
+#' equal weight unless they are told otherwise, and the remedy is to hand them
+#' the tilt as the weights of the average: `ps_tilt(ps, "att")` for a binary
+#' exposure and `ps_tilt(ps, "att", .focal_level = "b")` for a categorical one.
+#'
+#' The requirement is easy to miss because an outcome model saturated in the
+#' exposure hides it. Such a model predicts one value per exposure level, so
+#' every average of its predictions returns the same contrast, and there the
+#' estimand is settled by the weights the model was fit with rather than by the
+#' weights of the average: a model fit with [wt_att()] weights reports the ATT
+#' whether the average is taken with equal weight or with the tilt. The two
+#' averages come apart at the first covariate the outcome model adjusts for,
+#' where the predictions vary from row to row and the weights the average is
+#' taken under are what decides the population the estimate describes.
+#'
 #' # Propensity score range
 #'
 #' Every propensity score in `.propensity` must lie strictly inside

--- a/man/augment.ipw.Rd
+++ b/man/augment.ipw.Rd
@@ -63,6 +63,33 @@ plain numeric copy of the same values does not. The default frame therefore
 leaves \code{(weights)} out. A frame supplied through \code{data} is the caller's own
 and is carried as it arrives, so a weight column they hold stays where they
 put it, whatever it is named.
+
+A column is an answer per observation only while the fit it is read from and
+the frame it is carried on describe the same observations, so three things are
+refused rather than reported. A result whose propensity score model and
+outcome model were fit to different rows is refused, because the propensity
+score of one observation would arrive beside the fitted value of another. Two
+models of the same data most often part this way over missing values, each
+dropping the rows a variable of its own is missing on. What is compared is the
+number of observations each model produced an answer for and, when the outcome
+model's frame names the exposure, the exposure values of the two model frames
+position by position, reading a factor and the numbers its labels spell as one
+encoding of one exposure. Exposure values that disagree prove the two models
+hold different observations; exposure values that agree prove nothing, since
+two different sets of rows are free to carry the same sequence of values, and
+two encodings that cannot be read onto each other, such as a factor of \code{"a"}
+and \code{"b"} against a recoding of it as 0 and 1, prove nothing either way.
+The check is one-sided in that direction on purpose: it refuses only what it
+can prove, which is also why it never refuses a fit whose models do line up,
+however the rows of either are labeled. A frame
+that already holds a column this call would add is refused as well, because
+the fit's column has nowhere to go: added beside the frame's, the two would be
+told apart by nothing, and written over it, the frame's data would be gone.
+Which names are in the way depends on the fit and the frame, \code{.resid} being
+among them only for a frame it would be added to and the propensity columns
+being the ones the propensity score model produced. Last, a result whose
+outcome model was fit without weights is refused under the class \code{\link[=ipw]{ipw()}}
+refuses the same fact with: \code{.weights} has nothing to report for such a fit.
 }
 \examples{
 set.seed(123)

--- a/man/augment.ipw.Rd
+++ b/man/augment.ipw.Rd
@@ -80,11 +80,12 @@ two different sets of rows are free to carry the same sequence of values, and
 two encodings that cannot be read onto each other, such as a factor of \code{"a"}
 and \code{"b"} against a recoding of it as 0 and 1, prove nothing either way.
 The check is one-sided in that direction on purpose: it refuses only what it
-can prove, which is also why it never refuses a fit whose models do line up,
-however the rows of either are labeled. A frame
-that already holds a column this call would add is refused as well, because
-the fit's column has nowhere to go: added beside the frame's, the two would be
-told apart by nothing, and written over it, the frame's data would be gone.
+can prove, so a fit whose models do line up is never refused over the labels
+the rows of either frame carry or the encoding its exposure is written in. A
+frame that already holds a column this call would add is refused as well,
+because the fit's column has nowhere to go: added beside the frame's, the two
+would be told apart by nothing, and written over it, the frame's data would be
+gone.
 Which names are in the way depends on the fit and the frame, \code{.resid} being
 among them only for a frame it would be added to and the propensity columns
 being the ones the propensity score model produced. Last, a result whose

--- a/man/ipw-methods.Rd
+++ b/man/ipw-methods.Rd
@@ -148,7 +148,13 @@ account for the uncertainty of estimating the propensity scores.
 with an intercept; a covariate-adjusted outcome model requires
 \code{"mestimation"}. For a binary or categorical exposure, both methods require
 an outcome model that can represent a baseline, so a numeric no-intercept
-coding such as \code{y ~ z - 1} errors on either.}
+coding such as \code{y ~ z - 1} errors on either. The standard errors of the
+conditional reading described under \code{effects} require \code{"mestimation"}
+as well: the
+linearization route stores its outcome model unwrapped, so \code{\link[stats:vcov]{stats::vcov()}},
+\code{\link[stats:confint]{stats::confint()}}, and \code{\link[=tidy.ipw]{tidy()}} refuse
+\code{effects = "conditional"} there with a classed error rather than reporting
+the covariance the outcome model computed for itself.}
 
 \item{.focal_level}{For the categorical (\code{multinom}) method with the \code{att}
 or \code{atu} estimand, the focal exposure level. If \code{NULL}, it is taken from
@@ -285,6 +291,11 @@ with \code{\link[=wt_att]{wt_att()}} or \code{\link[=wt_atu]{wt_atu()}} on the o
 correct for the reversed roles, and \code{ipw()} rejects them rather than
 correcting them as though the roles matched. To target the other level,
 relevel the exposure so that it sorts second and refit both models.
+
+The estimand a weighted outcome model was fit for is not necessarily the one a
+tool that averages its per-row predictions reports, so see \strong{Standardizing
+model predictions} in \code{\link[=ps_tilt]{ps_tilt()}} before taking such an average of a model fit
+for anything other than \code{"ate"}.
 }
 
 \section{Effect measures}{
@@ -363,6 +374,11 @@ for an exposure-only outcome model. A covariate-adjusted outcome model (any
 term beyond the exposure, including covariates, interactions, or transformed
 terms) errors on the linearization path and requires
 \code{se_method = "mestimation"}, which stacks adjusted outcome models correctly.
+The conditional reading is restricted the same way: linearization stacks no
+system, so the outcome model it stores carries no block of one, and the
+standard errors that reading reports are refused with a classed error rather
+than replaced by the covariance the outcome model computed for itself, which
+treats the estimated weights as fixed.
 
 The linearization outcome model must also carry an intercept, which is a
 stricter requirement than the M-estimation path imposes. Under a numeric

--- a/man/ps_tilt.Rd
+++ b/man/ps_tilt.Rd
@@ -76,6 +76,32 @@ weight by a marginal quantity that does not depend on the covariates, and
 \code{wt_cens()} reuses the \code{"ate"} formula, so neither has an entry here.
 }
 
+\section{Standardizing model predictions}{
+A g-computation estimate averages an outcome model's per-row counterfactual
+predictions, and where those predictions vary from row to row it is the
+weights of that average that standardize the estimate to a target population.
+The tilt is those weights, which is what the second example below supplies by
+hand. An average taken with equal weight standardizes a covariate-adjusted
+outcome model to the whole sample, so such a model targets the ATE however its
+own fitting weights were built: fit for a non-\code{"ate"} estimand and averaged
+that way, it reports the full-sample contrast rather than the one it was
+weighted for. Tools that average per-row model predictions, such as the
+\code{avg_comparisons()} function in the marginaleffects package, average with
+equal weight unless they are told otherwise, and the remedy is to hand them
+the tilt as the weights of the average: \code{ps_tilt(ps, "att")} for a binary
+exposure and \code{ps_tilt(ps, "att", .focal_level = "b")} for a categorical one.
+
+The requirement is easy to miss because an outcome model saturated in the
+exposure hides it. Such a model predicts one value per exposure level, so
+every average of its predictions returns the same contrast, and there the
+estimand is settled by the weights the model was fit with rather than by the
+weights of the average: a model fit with \code{\link[=wt_att]{wt_att()}} weights reports the ATT
+whether the average is taken with equal weight or with the tilt. The two
+averages come apart at the first covariate the outcome model adjusts for,
+where the predictions vary from row to row and the weights the average is
+taken under are what decides the population the estimate describes.
+}
+
 \section{Propensity score range}{
 Every propensity score in \code{.propensity} must lie strictly inside
 \eqn{(0, 1)}, the same requirement \code{\link[=wt_ate]{wt_ate()}} and the rest of the weight

--- a/man/tidy.ipw.Rd
+++ b/man/tidy.ipw.Rd
@@ -24,7 +24,8 @@ between 0 and 1. Defaults to \code{0.95}, which is this method's own default
 rather than the level \code{x} was fit at. When the two differ, the bounds are
 recomputed as the normal approximation
 \verb{estimate +/- qnorm(1 - (1 - conf.level) / 2) * std.error}, which is the
-interval \code{\link[=ipw]{ipw()}} itself reports. Ignored when \code{conf.int} is \code{FALSE}.}
+interval \code{\link[=ipw]{ipw()}} itself reports. Not used when \code{conf.int} is \code{FALSE}, though
+it must still be a valid level.}
 
 \item{exponentiate}{Logical. Should the estimate and its bounds be
 exponentiated on the rows reported on the log scale? Defaults to \code{FALSE}.
@@ -93,11 +94,21 @@ column names broom conventions use. There is one row per effect measure, and
 one row per effect measure per comparison for a categorical exposure, in the
 order the result stores them. Nothing is dropped.
 
-The values are the ones the result already holds: \code{tidy()} renames and
-selects rather than re-estimating anything. The one exception is the
-confidence interval, which is rebuilt from the estimate and its standard
-error when the requested \code{conf.level} differs from the level the result was
-fit at.
+Those columns are the ones the result's own coercion surface reports, so the
+marginal reading is \code{\link[causalgenerics:new_ipw]{as.data.frame()}} read as a
+tibble rather than a second assembly of the same table. The values are the
+ones the result already holds, nothing being re-estimated: the confidence
+interval is the only thing rebuilt, and only when the requested \code{conf.level}
+differs from the level the result was fit at. The one thing the frame carries
+that the tibble does not is the covariance of the effects it attaches as an
+attribute, a tidied table being its columns.
+
+\code{conf.int}, \code{conf.level}, and \code{exponentiate} are the arguments this method
+shares with that surface, so the surface validates them, in both readings and
+before either is assembled. A value it refuses is reported under the
+causalgenerics condition naming the argument at fault, which is what keeps one
+argument of one method from being well formed in one reading of a result and
+refused in the other.
 
 A result reports its effects in one of two readings, and \code{tidy()} returns the
 one the result records unless \code{effects} names the other for the call. The

--- a/tests/testthat/_snaps/ipw-tidiers.md
+++ b/tests/testthat/_snaps/ipw-tidiers.md
@@ -1,0 +1,63 @@
+# augment(data = ) rejects data holding a column augment adds
+
+    Code
+      expr
+    Condition <propensity_augment_column_error>
+      Error in `augment()`:
+      ! `augment()` adds a column the frame carrying it already holds.
+      x The frame already holds ".fitted".
+      i Rename or drop it in `data`, or leave `data` as `NULL` to carry the fit's columns on the outcome model's own frame.
+
+# augment(data = ) names every column of the data it clashes with
+
+    Code
+      expr
+    Condition <propensity_augment_column_error>
+      Error in `augment()`:
+      ! `augment()` adds columns the frame carrying them already holds.
+      x The frame already holds ".propensity", ".weights", and ".fitted".
+      i Rename or drop them in `data`, or leave `data` as `NULL` to carry the fit's columns on the outcome model's own frame.
+
+# augment(data = ) clashes on the level columns of a categorical fit
+
+    Code
+      expr
+    Condition <propensity_augment_column_error>
+      Error in `augment()`:
+      ! `augment()` adds a column the frame carrying it already holds.
+      x The frame already holds ".propensity_b".
+      i Rename or drop it in `data`, or leave `data` as `NULL` to carry the fit's columns on the outcome model's own frame.
+
+# augment() rejects a result whose models saw different counts
+
+    Code
+      expr
+    Condition <propensity_augment_alignment_error>
+      Error in `augment()`:
+      ! `x` must hold two models fit to the same rows.
+      x The propensity score model produced 599 propensity scores.
+      x The outcome model was fit to 600 observations.
+      i Two models of the same data most often part this way over missing values, each dropping the rows a variable of its own is missing on.
+      i Refit both models on the rows that are complete on every variable either model uses.
+
+# augment() rejects a result whose models saw different rows
+
+    Code
+      expr
+    Condition <propensity_augment_alignment_error>
+      Error in `augment()`:
+      ! `x` must hold two models fit to the same rows.
+      x Both models were fit to 599 observations, and the "z" values in the two model frames disagree.
+      i Two models of the same data most often part this way over missing values, each dropping the rows a variable of its own is missing on.
+      i Refit both models on the rows that are complete on every variable either model uses.
+
+# augment() rejects a result whose outcome model has no weights
+
+    Code
+      expr
+    Condition <propensity_ipw_weights_missing_error>
+      Error in `augment()`:
+      ! `x` must hold an outcome model fit with propensity score weights.
+      x The outcome model `x` holds reports no weights.
+      i An `ipw()` outcome model is weighted by construction. Refit it with the weights the propensity score model implies, such as those `wt_ate()` returns.
+

--- a/tests/testthat/test-ipw-base-methods.R
+++ b/tests/testthat/test-ipw-base-methods.R
@@ -484,6 +484,11 @@ test_that("a stabilized fit spends an observation on its stabilizer", {
     se_method = "mestimation"
   )
 
+  # The weights the result reports are the stabilized vector the outcome model
+  # was fit with, so the stabilization travels with the fit rather than living
+  # only in the fixture.
+  expect_identical(weights(res), stabilized$wts)
+
   # The stabilizer is solved for rather than held fixed, so it is a parameter of
   # the stacked system and sits between the propensity score block and the
   # outcome block. Everything else the system solves for is what the
@@ -503,7 +508,7 @@ test_that("a stabilized fit spends an observation on its stabilizer", {
   # The row that parameter answers is the mean of the centered exposure, whose
   # root is the marginal exposure probability, so the solved value is the
   # proportion exposed rather than anything the weights were scaled by
-  # approximately. The solver reaches it to within one unit in the last place, a
+  # approximately. The solver reaches it to within two units in the last place, a
   # measured 1.1e-16 on this fixture, so the comparison carries a tolerance
   # rather than asking for the same double.
   expect_equal(res$fit@theta[["stab_pi"]], mean(dat$z), tolerance = 1e-12)

--- a/tests/testthat/test-ipw-base-methods.R
+++ b/tests/testthat/test-ipw-base-methods.R
@@ -82,17 +82,24 @@ sim_base_continuous <- function(seed = 2024, n = 600) {
 # models serves the M-estimation and the linearization paths, the latter being
 # restricted to marginal outcome models. `estimand` picks the weighting scheme,
 # so a fit reporting something other than the ATE is available here rather than
-# through a second fixture.
+# through a second fixture. `stabilize` scales the ATE weights by the marginal
+# exposure probability, which the stacked system solves for as a parameter of
+# its own rather than holding fixed. Stabilization is defined for the ATE alone,
+# so the ATT branch takes no such argument.
 fit_base_binary_models <- function(
   dat,
   outcome_family = "binomial",
-  estimand = "ate"
+  estimand = "ate",
+  stabilize = FALSE
 ) {
   ps_mod <- glm(z ~ x1 + x2, data = dat, family = binomial())
-  wt_fun <- if (estimand == "att") wt_att else wt_ate
   wts <- withr::with_options(
     list(propensity.quiet = TRUE),
-    wt_fun(ps_mod)
+    if (estimand == "att") {
+      wt_att(ps_mod)
+    } else {
+      wt_ate(ps_mod, stabilize = stabilize)
+    }
   )
   outcome_var <- if (outcome_family == "binomial") "y" else "yc"
   fmla <- stats::reformulate("z", response = outcome_var)
@@ -329,6 +336,21 @@ test_that("a binary att fit records the covariance of its effects", {
   expect_identical(rownames(covariance), c("rd", "log(rr)", "log(or)"))
 })
 
+test_that("a stabilized binary fit records the covariance of its effects", {
+  skip_if_not_installed("deli")
+  dat <- sim_base_binary()
+  mods <- fit_base_binary_models(dat, stabilize = TRUE)
+  res <- ipw(mods$ps_mod, mods$outcome_mod, se_method = "mestimation")
+
+  # Stabilizing the weights adds a parameter to the stacked system, so the
+  # sandwich the covariance is read off is a wider matrix than the unstabilized
+  # fit's. What the estimates table is owed is unchanged: the covariance of the
+  # three effect measures it reports, carrying their standard errors.
+  expect_true(is_stabilized(mods$wts))
+  covariance <- expect_ipw_vcov_contract(res)
+  expect_identical(rownames(covariance), c("rd", "log(rr)", "log(or)"))
+})
+
 test_that("a categorical fit labels its covariance by effect and comparison", {
   skip_if_not_installed("nnet")
   skip_if_not_installed("deli")
@@ -441,6 +463,50 @@ test_that("the accessors read a binary mestimation fit", {
   # spent on.
   expect_identical(nobs(res), 600L)
   expect_identical(df.residual(res), 600L - as.integer(res$fit@n_params))
+})
+
+test_that("a stabilized fit spends an observation on its stabilizer", {
+  skip_if_not_installed("deli")
+  dat <- sim_base_binary()
+  stabilized <- fit_base_binary_models(dat, stabilize = TRUE)
+  unstabilized <- fit_base_binary_models(dat)
+  expect_true(is_stabilized(stabilized$wts))
+  expect_false(is_stabilized(unstabilized$wts))
+
+  res <- ipw(
+    stabilized$ps_mod,
+    stabilized$outcome_mod,
+    se_method = "mestimation"
+  )
+  base <- ipw(
+    unstabilized$ps_mod,
+    unstabilized$outcome_mod,
+    se_method = "mestimation"
+  )
+
+  # The stabilizer is solved for rather than held fixed, so it is a parameter of
+  # the stacked system and sits between the propensity score block and the
+  # outcome block. Everything else the system solves for is what the
+  # unstabilized fit solves for, in the same order.
+  theta_names <- names(res$fit@theta)
+  expect_identical(theta_names[[4]], "stab_pi")
+  expect_identical(theta_names[-4], names(base$fit@theta))
+
+  # An observation is spent on that parameter, so the counts describing the fit
+  # report one fewer residual degree of freedom than the unstabilized fit of the
+  # same data does.
+  expect_identical(as.integer(res$fit@n_params), 11L)
+  expect_identical(nobs(res), 600L)
+  expect_identical(df.residual(res), 589L)
+  expect_identical(df.residual(res), df.residual(base) - 1L)
+
+  # The row that parameter answers is the mean of the centered exposure, whose
+  # root is the marginal exposure probability, so the solved value is the
+  # proportion exposed rather than anything the weights were scaled by
+  # approximately. The solver reaches it to within one unit in the last place, a
+  # measured 1.1e-16 on this fixture, so the comparison carries a tolerance
+  # rather than asking for the same double.
+  expect_equal(res$fit@theta[["stab_pi"]], mean(dat$z), tolerance = 1e-12)
 })
 
 test_that("the accessors read a binary linearization fit", {

--- a/tests/testthat/test-ipw-categorical.R
+++ b/tests/testthat/test-ipw-categorical.R
@@ -625,9 +625,20 @@ test_that("as.data.frame(exponentiate = TRUE) relabels ratios per comparison", {
 
   df <- as.data.frame(res, exponentiate = TRUE)
 
+  # The frame reports the effect measure under `term`, and `comparison` follows
+  # the term it qualifies. The bounds are not columns of it: they arrive only
+  # when `conf.int` asks for them.
+  expect_named(
+    df,
+    c("term", "comparison", "estimate", "std.error", "statistic", "p.value")
+  )
+
   # the ratio rows are relabelled while the comparison column is preserved
-  expect_equal(df$effect, rep(c("rd", "rr", "or"), times = 2))
+  expect_equal(df$term, rep(c("rd", "rr", "or"), times = 2))
   expect_equal(df$comparison, rep(c("b vs a", "c vs a"), each = 3))
+
+  # the standard error describes the log scale estimate and stays there
+  expect_equal(df$std.error, as.data.frame(res)$std.error)
 })
 
 # ---- a transformed exposure in the outcome formula ---------------------------

--- a/tests/testthat/test-ipw-continuous.R
+++ b/tests/testthat/test-ipw-continuous.R
@@ -348,7 +348,11 @@ test_that("as.data.frame(exponentiate = TRUE) relabels the continuous log odds r
 
   df <- as.data.frame(res, exponentiate = TRUE)
   expect_equal(nrow(df), 1L)
-  expect_equal(df$effect, "or")
+  expect_named(
+    df,
+    c("term", "estimate", "std.error", "statistic", "p.value")
+  )
+  expect_equal(df$term, "or")
 })
 
 # ---- offset guard -----------------------------------------------------------

--- a/tests/testthat/test-ipw-provenance.R
+++ b/tests/testthat/test-ipw-provenance.R
@@ -498,68 +498,108 @@ test_that("printing an ipw result returns it invisibly", {
   expect_identical(print(res), res)
 })
 
-test_that("as.data.frame() on an ipw result returns the estimates component", {
+test_that("as.data.frame() on an ipw result returns the estimates in tidy columns", {
   res <- fit_ipw_binary(sim_ipw_binary())
   df <- as.data.frame(res)
+  estimates <- res$estimates
 
   expect_s3_class(df, "data.frame")
   expect_named(
     df,
+    c("term", "estimate", "std.error", "statistic", "p.value")
+  )
+  expect_identical(df$term, c("rd", "log(rr)", "log(or)"))
+
+  # The values are the result's own, renamed rather than recomputed.
+  expect_identical(df$estimate, estimates$estimate)
+  expect_identical(df$std.error, estimates$std.err)
+  expect_identical(df$statistic, estimates$z)
+  expect_identical(df$p.value, estimates$p.value)
+
+  # The bounds are not columns of the default frame: they arrive, under the
+  # names the broom column conventions use, only when `conf.int` asks for them.
+  # The level they were built at is an argument rather than a column, and is
+  # reported by neither frame.
+  bounded <- as.data.frame(res, conf.int = TRUE)
+  expect_named(
+    bounded,
     c(
-      "effect",
+      "term",
       "estimate",
-      "std.err",
-      "z",
-      "ci.lower",
-      "ci.upper",
-      "conf.level",
-      "p.value"
+      "std.error",
+      "statistic",
+      "p.value",
+      "conf.low",
+      "conf.high"
     )
   )
-  expect_equal(df, res$estimates)
-  expect_identical(df$effect, c("rd", "log(rr)", "log(or)"))
+  expect_identical(bounded$conf.low, estimates$ci.lower)
+  expect_identical(bounded$conf.high, estimates$ci.upper)
+
+  # The covariance of the reported effects travels with the frame, since it is
+  # recoverable from nothing else the frame carries.
+  expect_identical(
+    attr(df, "ipw_vcov", exact = TRUE),
+    attr(estimates, "ipw_vcov", exact = TRUE)
+  )
 
   # `row.names` reaches `base::as.data.frame()`.
   named <- as.data.frame(res, row.names = c("a", "b", "c"))
   expect_identical(rownames(named), c("a", "b", "c"))
 
   # `optional` is part of the signature `base::as.data.frame()` requires. The
-  # data frame method ignores it, so it must be accepted and leave the
-  # estimates untouched rather than error or reshape them.
-  expect_equal(as.data.frame(res, optional = TRUE), res$estimates)
+  # data frame method ignores it, so it must be accepted and leave the frame
+  # untouched rather than error or reshape it.
+  expect_identical(as.data.frame(res, optional = TRUE), df)
 
-  # `...` passes through to `base::as.data.frame()`. An argument the data frame
-  # method does not use is absorbed there, not rejected as unused here.
-  expect_equal(as.data.frame(res, stringsAsFactors = FALSE), res$estimates)
+  # An argument the method does not use is absorbed by the dots, not rejected
+  # as unused here.
+  expect_identical(as.data.frame(res, stringsAsFactors = FALSE), df)
 })
 
 test_that("exponentiating an ipw result transforms only the estimate and bounds", {
   res <- fit_ipw_binary(sim_ipw_binary())
-  log_scale <- as.data.frame(res)
-  exp_scale <- as.data.frame(res, exponentiate = TRUE)
+  log_scale <- as.data.frame(res, conf.int = TRUE)
+  exp_scale <- as.data.frame(res, conf.int = TRUE, exponentiate = TRUE)
 
-  ratio <- log_scale$effect %in% c("log(rr)", "log(or)")
+  ratio <- log_scale$term %in% c("log(rr)", "log(or)")
 
-  expect_identical(exp_scale$effect, c("rd", "rr", "or"))
+  expect_identical(exp_scale$term, c("rd", "rr", "or"))
   expect_equal(exp_scale$estimate[ratio], exp(log_scale$estimate[ratio]))
-  expect_equal(exp_scale$ci.lower[ratio], exp(log_scale$ci.lower[ratio]))
-  expect_equal(exp_scale$ci.upper[ratio], exp(log_scale$ci.upper[ratio]))
+  expect_equal(exp_scale$conf.low[ratio], exp(log_scale$conf.low[ratio]))
+  expect_equal(exp_scale$conf.high[ratio], exp(log_scale$conf.high[ratio]))
 
-  # The standard error, z statistic, and p-value stay on the log scale.
-  expect_identical(exp_scale$std.err, log_scale$std.err)
-  expect_identical(exp_scale$z, log_scale$z)
+  # The standard error, test statistic, and p-value stay on the log scale.
+  expect_identical(exp_scale$std.error, log_scale$std.error)
+  expect_identical(exp_scale$statistic, log_scale$statistic)
   expect_identical(exp_scale$p.value, log_scale$p.value)
-  expect_identical(exp_scale$conf.level, log_scale$conf.level)
 
-  # The risk difference row is untouched, label included.
-  expect_equal(exp_scale[!ratio, ], log_scale[!ratio, ])
+  # The covariance describes the effects on the log scale, so a frame that has
+  # moved any of them off it carries none.
+  expect_false(is.null(attr(log_scale, "ipw_vcov", exact = TRUE)))
+  expect_null(attr(exp_scale, "ipw_vcov", exact = TRUE))
+
+  # The risk difference row is untouched, label included. Subsetting rows
+  # carries the covariance of the whole table along with the row it kept, so it
+  # is set aside here rather than compared as though it described that row.
+  on_log_scale <- log_scale
+  attr(on_log_scale, "ipw_vcov") <- NULL
+  expect_equal(exp_scale[!ratio, ], on_log_scale[!ratio, ])
 })
 
 test_that("exponentiating a difference-only ipw result changes nothing", {
   res <- fit_ipw_binary(sim_ipw_binary(), outcome = "continuous")
+  plain <- as.data.frame(res, conf.int = TRUE)
+  exponentiated <- as.data.frame(res, conf.int = TRUE, exponentiate = TRUE)
 
-  expect_identical(as.data.frame(res)$effect, "diff")
-  expect_equal(as.data.frame(res, exponentiate = TRUE), as.data.frame(res))
+  expect_identical(plain$term, "diff")
+
+  # No row of this table is on a log scale, so every column arrives as it was.
+  # The covariance is the one thing the exponentiated frame drops, and it drops
+  # it whether or not any row moved.
+  expect_null(attr(exponentiated, "ipw_vcov", exact = TRUE))
+  attr(plain, "ipw_vcov") <- NULL
+  expect_equal(exponentiated, plain)
 })
 
 test_that("a categorical ipw result keeps its comparison column through both surfaces", {
@@ -567,15 +607,15 @@ test_that("a categorical ipw result keeps its comparison column through both sur
   res <- fit_ipw_categorical(sim_ipw_categorical())
 
   df <- as.data.frame(res)
-  expect_identical(names(df)[seq(1, 2)], c("effect", "comparison"))
+  expect_identical(names(df)[seq(1, 2)], c("term", "comparison"))
   expect_identical(df$comparison, rep(c("b vs a", "c vs a"), each = 3))
 
   exp_scale <- as.data.frame(res, exponentiate = TRUE)
-  ratio <- df$effect %in% c("log(rr)", "log(or)")
-  expect_identical(exp_scale$effect, rep(c("rd", "rr", "or"), times = 2))
+  ratio <- df$term %in% c("log(rr)", "log(or)")
+  expect_identical(exp_scale$term, rep(c("rd", "rr", "or"), times = 2))
   expect_identical(exp_scale$comparison, df$comparison)
   expect_equal(exp_scale$estimate[ratio], exp(df$estimate[ratio]))
-  expect_identical(exp_scale$std.err, df$std.err)
+  expect_identical(exp_scale$std.error, df$std.error)
 
   # print() keys the rows by effect and comparison together and drops the
   # character comparison column from the matrix it formats.

--- a/tests/testthat/test-ipw-rank-deficiency.R
+++ b/tests/testthat/test-ipw-rank-deficiency.R
@@ -755,14 +755,17 @@ test_that("a healthy fit of a small-unit outcome reports no collapse", {
 test_that("a small-unit outcome keeps an informative test statistic", {
   skip_if_not_installed("deli")
   mods <- small_scale_outcome_fit()
-  est <- as.data.frame(ipw(mods$ps_mod, mods$out, se_method = "mestimation"))
+  est <- as.data.frame(
+    ipw(mods$ps_mod, mods$out, se_method = "mestimation"),
+    conf.int = TRUE
+  )
 
   # the fit the report would have to be about: every number in the table near
   # machine precision, and an interval that excludes zero
   expect_lt(abs(est$estimate), 1e-8)
-  expect_lt(est$std.err, 1e-8)
-  expect_gt(abs(est$z), 3)
-  expect_gt(est$ci.lower, 0)
+  expect_lt(est$std.error, 1e-8)
+  expect_gt(abs(est$statistic), 3)
+  expect_gt(est$conf.low, 0)
 })
 
 # ---- a standard error of exactly zero ---------------------------------------
@@ -822,12 +825,12 @@ test_that("the degenerate signature reads the test statistic, not the scale", {
 
 degenerate_se_z <- function(res) {
   est <- as.data.frame(res)
-  max(abs(est$estimate) / est$std.err)
+  max(abs(est$estimate) / est$std.error)
 }
 
 degenerate_se_min_z <- function(res) {
   est <- as.data.frame(res)
-  min(abs(est$estimate) / est$std.err)
+  min(abs(est$estimate) / est$std.error)
 }
 
 test_that("healthy fits clear the degenerate-standard-error threshold by orders", {

--- a/tests/testthat/test-ipw-se-method.R
+++ b/tests/testthat/test-ipw-se-method.R
@@ -444,8 +444,8 @@ test_that("as.data.frame(exponentiate = TRUE) matches across SE methods", {
 
   # Both paths relabel the ratio rows and share point estimates on the natural
   # scale (standard errors stay on the log scale and may differ by method).
-  expect_equal(df_m$effect, c("rd", "rr", "or"))
-  expect_equal(df_l$effect, c("rd", "rr", "or"))
+  expect_equal(df_m$term, c("rd", "rr", "or"))
+  expect_equal(df_l$term, c("rd", "rr", "or"))
   expect_equal(df_m$estimate, df_l$estimate, tolerance = 1e-8)
 })
 

--- a/tests/testthat/test-ipw-tidiers.R
+++ b/tests/testthat/test-ipw-tidiers.R
@@ -173,6 +173,67 @@ fit_tidy_continuous_models <- function(dat, outcome_family = "gaussian") {
   list(ps_mod = ps_mod, outcome_mod = outcome_mod)
 }
 
+# A propensity score model and an outcome model fit to different rows. Each
+# argument names a row to blank out in a covariate one model uses and the other
+# does not, so the model using that covariate drops the row and the other keeps
+# it: a row blanked for the propensity score model alone leaves the two models
+# with different counts, and a different row blanked for each leaves them with
+# the same count and different rows. The weights come from a propensity score
+# model of the complete data, which gives the outcome model a weight for every
+# row it keeps whichever rows those are.
+fit_tidy_misaligned_models <- function(
+  dat,
+  ps_row = integer(),
+  outcome_row = integer()
+) {
+  withr::local_seed(825)
+  dat$xp <- rnorm(nrow(dat))
+  dat$xo <- rnorm(nrow(dat))
+  dat$xp[ps_row] <- NA
+  dat$xo[outcome_row] <- NA
+
+  wts <- withr::with_options(
+    list(propensity.quiet = TRUE),
+    wt_ate(glm(z ~ x1 + x2, data = dat, family = binomial()))
+  )
+
+  list(
+    ps_mod = glm(z ~ x1 + xp, data = dat, family = binomial()),
+    outcome_mod = glm(
+      y ~ z + xo,
+      data = dat,
+      family = quasibinomial(),
+      weights = wts
+    )
+  )
+}
+
+# A result assembled around a pair of models without the checks `ipw()` makes on
+# the pair it is given. The estimator refuses two models fit to different rows
+# and refuses an outcome model fit without weights, so a result holding either
+# reaches a method only through the class's own constructor. `augment()` reads
+# the two models and never the estimates table, which is why the table here is
+# the shape of one rather than a fit's own.
+new_tidy_ipw <- function(ps_mod, outcome_mod) {
+  causalgenerics::new_ipw(
+    estimand = "ate",
+    wt_mod = ps_mod,
+    outcome_mod = outcome_mod,
+    estimates = data.frame(
+      effect = "rd",
+      estimate = 0,
+      std.err = 0,
+      z = 0,
+      ci.lower = 0,
+      ci.upper = 0,
+      conf.level = 0.95,
+      p.value = 1
+    ),
+    se_method = "linearization",
+    fit = NULL
+  )
+}
+
 # ---- expected shape ----------------------------------------------------------
 
 # The broom column contract. `comparison` is the categorical extra column and
@@ -1209,6 +1270,111 @@ test_that("augment(data = ) rejects data that is not one row per observation", {
   )
 })
 
+test_that("augment(data = ) rejects data holding a column augment adds", {
+  dat <- sim_tidy_binary()
+  mods <- fit_tidy_binary_models(dat)
+  res <- ipw(mods$ps_mod, mods$outcome_mod, se_method = "linearization")
+
+  # `.fitted` is one of the columns the fit's answers are reported in, so a
+  # frame that already holds a column of that name has nowhere for the fit's own
+  # to go. Adding it beside the caller's would return a frame naming two columns
+  # `.fitted`, and writing over it would delete their data.
+  collide <- dat
+  collide$.fitted <- 0
+
+  expect_error(
+    augment(res, data = collide),
+    class = "propensity_augment_column_error"
+  )
+})
+
+test_that("augment(data = ) names every column of the data it clashes with", {
+  dat <- sim_tidy_binary()
+  mods <- fit_tidy_binary_models(dat)
+  res <- ipw(mods$ps_mod, mods$outcome_mod, se_method = "linearization")
+
+  # A frame can clash on more than one column, and a report of one of them
+  # leaves the caller to rename that column and meet the next refusal. Every
+  # column that clashes is named at once. `.propensity` is among them here: a
+  # binary or continuous exposure reports its propensity score in the one column
+  # of that name, which is as much in the way as the other three.
+  collide <- dat
+  collide$.propensity <- 0.5
+  collide$.weights <- 1
+  collide$.fitted <- 0
+
+  err <- expect_error(
+    augment(res, data = collide),
+    class = "propensity_augment_column_error"
+  )
+  msg <- gsub("[[:space:]]+", " ", conditionMessage(err))
+  expect_match(msg, ".propensity", fixed = TRUE)
+  expect_match(msg, ".weights", fixed = TRUE)
+  expect_match(msg, ".fitted", fixed = TRUE)
+})
+
+test_that("augment(data = ) counts a .resid column only when it adds one", {
+  dat <- sim_tidy_binary()
+  mods <- fit_tidy_binary_models(dat)
+  res <- ipw(mods$ps_mod, mods$outcome_mod, se_method = "linearization")
+
+  # `.resid` is added only to a frame holding the outcome to difference, so
+  # whether a `.resid` column of the caller's is in the way depends on the frame
+  # it arrives in. A frame with no outcome column is given no residual, and the
+  # caller's column of that name goes through as any other column of theirs
+  # would.
+  covariates <- dat[c("x1", "x2", "z")]
+  covariates$.resid <- 0
+  expect_augment_contract(
+    augment(res, data = covariates),
+    covariates,
+    res,
+    resid = FALSE
+  )
+
+  # The same column in a frame that does hold the outcome is a column the
+  # residual would be written over.
+  with_outcome <- dat
+  with_outcome$.resid <- 0
+
+  expect_error(
+    augment(res, data = with_outcome),
+    class = "propensity_augment_column_error"
+  )
+})
+
+test_that("augment(data = ) clashes on the level columns of a categorical fit", {
+  skip_if_not_installed("nnet")
+  skip_if_not_installed("deli")
+  dat <- sim_tidy_categorical()
+  mods <- fit_tidy_categorical_models(dat)
+  res <- ipw(mods$ps_mod, mods$outcome_mod)
+
+  # A categorical exposure widens `.propensity` into one column per level, so
+  # the propensity columns in the way of this fit are those, named for the
+  # levels the propensity score model holds.
+  collide <- dat
+  collide$.propensity_b <- 0
+
+  expect_error(
+    augment(res, data = collide),
+    class = "propensity_augment_column_error"
+  )
+
+  # `.propensity` is not one of them on this route. No column of that name is
+  # added, so a column of the caller's carrying it is theirs to keep, which is
+  # what makes the clash a question about the columns this fit adds rather than
+  # about a fixed list of names.
+  kept <- dat
+  kept$.propensity <- 0
+  expect_augment_contract(
+    augment(res, data = kept),
+    kept,
+    res,
+    propensity_cols = paste0(".propensity_", mods$ps_mod$lev)
+  )
+})
+
 test_that("augment() rejects an argument that lands in the dots", {
   dat <- sim_tidy_binary()
   mods <- fit_tidy_binary_models(dat)
@@ -1220,6 +1386,112 @@ test_that("augment() rejects an argument that lands in the dots", {
   expect_error(
     augment(res, newdata = dat),
     class = "rlib_error_dots_nonempty"
+  )
+})
+
+# ---- augment, results ipw() would not have built ------------------------------
+
+# `augment()` reads the two models a result holds and reports a column of each
+# beside the other, which is an answer per observation only while the two models
+# describe the same observations. `ipw()` checks that of the pair it is handed,
+# so the pairs here are assembled into results directly: two fit to different
+# rows, one fit to the same rows that the method has no reason to refuse, and
+# one whose outcome model carries no weights at all.
+
+test_that("augment() rejects a result whose models saw different counts", {
+  dat <- sim_tidy_binary()
+  mods <- fit_tidy_misaligned_models(dat, ps_row = 7)
+  res <- new_tidy_ipw(mods$ps_mod, mods$outcome_mod)
+
+  # The propensity score model dropped the row its covariate was missing on and
+  # the outcome model kept every row, so from the seventh row on the two models
+  # are describing different observations. Carrying the shorter column beside
+  # the longer ones would report one observation's propensity score against
+  # another's fitted value.
+  expect_identical(as.integer(stats::nobs(mods$ps_mod)), 599L)
+  expect_identical(nrow(stats::model.frame(mods$outcome_mod)), 600L)
+
+  err <- expect_error(
+    augment(res),
+    class = "propensity_augment_alignment_error"
+  )
+
+  # Both counts are reported: which model dropped rows is the first thing a
+  # reader needs, and the difference between the two is what says so.
+  msg <- gsub("[[:space:]]+", " ", conditionMessage(err))
+  expect_match(msg, "\\b599\\b")
+  expect_match(msg, "\\b600\\b")
+})
+
+test_that("augment() rejects a result whose models saw different rows", {
+  dat <- sim_tidy_binary()
+  mods <- fit_tidy_misaligned_models(dat, ps_row = 7, outcome_row = 12)
+  res <- new_tidy_ipw(mods$ps_mod, mods$outcome_mod)
+
+  # Each model dropped one row and they dropped different ones, so the counts
+  # agree and the rows do not. A count is all that a column of the right length
+  # proves; the row names the two models kept are what says whether the
+  # observation in a row of one is the observation in that row of the other.
+  ps_rows <- names(stats::predict(mods$ps_mod, type = "response"))
+  outcome_rows <- rownames(stats::model.frame(mods$outcome_mod))
+  expect_identical(length(ps_rows), length(outcome_rows))
+  expect_false(identical(ps_rows, outcome_rows))
+
+  expect_error(
+    augment(res),
+    class = "propensity_augment_alignment_error"
+  )
+})
+
+test_that("augment() carries a fit whose two models dropped the same row", {
+  dat <- sim_tidy_binary()
+  mods <- fit_tidy_misaligned_models(dat, ps_row = 7, outcome_row = 7)
+  res <- new_tidy_ipw(mods$ps_mod, mods$outcome_mod)
+
+  # Both models were missing a covariate on the same row, so both dropped it and
+  # both describe the same 599 observations. The rows they kept are numbered
+  # around the gap that leaves, which is what a fit of incomplete data looks
+  # like and is not a reason to refuse anything: what makes two models
+  # comparable is that they kept the same rows, not that those rows run from one
+  # to the number of them.
+  outcome_rows <- rownames(stats::model.frame(mods$outcome_mod))
+  expect_identical(outcome_rows, as.character(c(1:6, 8:600)))
+  expect_identical(
+    names(stats::predict(mods$ps_mod, type = "response")),
+    outcome_rows
+  )
+
+  augmented <- augment(res)
+  expect_augment_contract(
+    augmented,
+    augment_source_frame(mods$outcome_mod),
+    res
+  )
+  expect_identical(nrow(augmented), 599L)
+  expect_identical(
+    augmented$.propensity,
+    unname(stats::predict(mods$ps_mod, type = "response"))
+  )
+})
+
+test_that("augment() rejects a result whose outcome model has no weights", {
+  dat <- sim_tidy_binary()
+  mods <- fit_tidy_binary_models(dat)
+  unweighted <- glm(y ~ z, data = dat, family = quasibinomial())
+  res <- new_tidy_ipw(mods$ps_mod, unweighted)
+
+  # The outcome model of an IPW result is a weighted one by construction, so a
+  # result reporting an outcome model with no weights to read is a result built
+  # around something else. `.weights` has nothing to hold, and a frame of the
+  # remaining columns would describe a fit the object does not name.
+  expect_null(stats::model.weights(stats::model.frame(unweighted)))
+
+  # The missing weights are the same fact `ipw()` refuses the pair for, so they
+  # are reported under the class that names that fact. Which method noticed it
+  # is not what a condition class is for.
+  expect_error(
+    augment(res),
+    class = "propensity_ipw_weights_missing_error"
   )
 })
 

--- a/tests/testthat/test-ipw-tidiers.R
+++ b/tests/testthat/test-ipw-tidiers.R
@@ -1,9 +1,13 @@
-# Tests for the broom tidiers on `ipw` results. `tidy()` reshapes the object's
-# `estimates` table into the column names the tidymodels broom developer guide
+# Tests for the broom tidiers on `ipw` results. `tidy()` reports the object's
+# `estimates` table under the column names the tidymodels broom developer guide
 # specifies, one row per estimate, adding interval bounds only when asked for
-# them. The values themselves are the object's own: the tidier renames and
-# selects, and recomputes only when a requested confidence level differs from
-# the one the fit stored.
+# them. The values themselves are the object's own: nothing is re-estimated, and
+# the interval is recomputed only when a requested confidence level differs from
+# the one the fit stored. Those columns are the ones the result's own coercion
+# surface reports, so the marginal reading of the tidier is that surface read as
+# a tibble rather than a second assembly of the same table, and the two are
+# pinned against each other as such. The covariance of the effects the frame
+# attaches is the one thing that does not travel: a tidied table is its columns.
 #
 # `glance()` describes the fit rather than its estimates: a single row naming the
 # estimand and counting the observations and the residual degrees of freedom of
@@ -364,6 +368,34 @@ expect_tidy_contract <- function(
   invisible(tidied)
 }
 
+# The marginal reading is the result's own coercion surface read as a tibble:
+# the same columns holding the same values, for either setting of the two
+# arguments this sweeps, `conf.int` and `exponentiate`. The third argument the
+# two surfaces share, `conf.level`, is pinned by value beside the interval it
+# governs. What the tibble does not carry is the
+# covariance of the effects the frame attaches. That covariance is an attribute
+# rather than a column, and a tidied table is its columns, so `tidy()` reports
+# none, and the pin says so rather than leaving the absence to be inferred from
+# the columns agreeing.
+expect_tidy_wraps_frame <- function(
+  result,
+  conf.int = FALSE,
+  exponentiate = FALSE
+) {
+  expected <- tibble::as_tibble(as.data.frame(
+    result,
+    conf.int = conf.int,
+    exponentiate = exponentiate
+  ))
+  attr(expected, "ipw_vcov") <- NULL
+
+  tidied <- tidy(result, conf.int = conf.int, exponentiate = exponentiate)
+  expect_identical(tidied, expected)
+  expect_null(attr(tidied, "ipw_vcov", exact = TRUE))
+
+  invisible(tidied)
+}
+
 # The conditional reading of a result, read off the accessors rather than off the
 # tidier: the outcome model's coefficients, the standard errors the joint block
 # implies, and the normal statistics those two make. Reading them from the
@@ -645,6 +677,74 @@ test_that("tidy() returns the log odds ratio row for a continuous logit fit", {
   expect_identical(tidied$term, "log(or)")
 })
 
+# ---- the frame the marginal reading wraps ------------------------------------
+
+# The marginal reading and the result's own coercion surface report the same
+# table, so the tidier is that surface read as a tibble rather than a second
+# assembly of the same columns that has to be kept in step with it by hand. The
+# equivalence is pinned once per exposure type, because each type reaches the
+# coercion surface with a table of its own shape: a binary exposure with the
+# three effect measures, a categorical one with those measures once per
+# comparison and the column naming it, and a continuous one with a single row.
+#
+# The frame carries the covariance of the effects it reports as an attribute.
+# The tibble does not: a tidied table is its columns, and a covariance is not
+# one of them.
+
+test_that("tidy() reports the coercion surface of a binary fit as a tibble", {
+  skip_if_not_installed("deli")
+  dat <- sim_tidy_binary()
+  mods <- fit_tidy_binary_models(dat)
+  res <- ipw(mods$ps_mod, mods$outcome_mod, se_method = "mestimation")
+
+  # The attribute is on the frame to be dropped in the first place, which is
+  # what makes its absence from the tibble a fact about the tidier.
+  expect_false(is.null(
+    attr(as.data.frame(res, conf.int = TRUE), "ipw_vcov", exact = TRUE)
+  ))
+
+  expect_tidy_wraps_frame(res)
+  expect_tidy_wraps_frame(res, conf.int = TRUE)
+
+  # An exponentiated frame reports estimates the covariance no longer describes
+  # and so carries none of its own. The tibble carries none either way.
+  expect_null(
+    attr(as.data.frame(res, exponentiate = TRUE), "ipw_vcov", exact = TRUE)
+  )
+  expect_tidy_wraps_frame(res, conf.int = TRUE, exponentiate = TRUE)
+})
+
+test_that("tidy() reports the coercion surface of a categorical fit as a tibble", {
+  skip_if_not_installed("nnet")
+  skip_if_not_installed("deli")
+  dat <- sim_tidy_categorical()
+  mods <- fit_tidy_categorical_models(dat)
+  res <- ipw(mods$ps_mod, mods$outcome_mod)
+
+  expect_false(is.null(
+    attr(as.data.frame(res, conf.int = TRUE), "ipw_vcov", exact = TRUE)
+  ))
+
+  expect_tidy_wraps_frame(res)
+  expect_tidy_wraps_frame(res, conf.int = TRUE)
+  expect_tidy_wraps_frame(res, conf.int = TRUE, exponentiate = TRUE)
+})
+
+test_that("tidy() reports the coercion surface of a continuous fit as a tibble", {
+  skip_if_not_installed("deli")
+  dat <- sim_tidy_continuous()
+  mods <- fit_tidy_continuous_models(dat, outcome_family = "binomial")
+  res <- ipw(mods$ps_mod, mods$outcome_mod)
+
+  expect_false(is.null(
+    attr(as.data.frame(res, conf.int = TRUE), "ipw_vcov", exact = TRUE)
+  ))
+
+  expect_tidy_wraps_frame(res)
+  expect_tidy_wraps_frame(res, conf.int = TRUE)
+  expect_tidy_wraps_frame(res, conf.int = TRUE, exponentiate = TRUE)
+})
+
 # ---- confidence level --------------------------------------------------------
 
 test_that("tidy() recomputes the interval at a non-default conf.level", {
@@ -715,34 +815,103 @@ test_that("tidy() rejects a conf.level that is not one number inside (0, 1)", {
   mods <- fit_tidy_binary_models(dat)
   res <- ipw(mods$ps_mod, mods$outcome_mod, se_method = "linearization")
 
+  # The condition is the one the result's own coercion surface raises for the
+  # same value, which is where the marginal reading takes the argument.
+  # Validating it under a class of this package's own would report one refusal
+  # under two names depending on which surface the user reached it through.
+  #
   # The endpoints are excluded: a level of 0 or 1 has no normal-approximation
   # interval to report.
   expect_error(
     tidy(res, conf.int = TRUE, conf.level = 1),
-    class = "propensity_conf_level_error"
+    class = "causalgenerics_invalid_argument_conf.level"
   )
   expect_error(
     tidy(res, conf.int = TRUE, conf.level = 0),
-    class = "propensity_conf_level_error"
+    class = "causalgenerics_invalid_argument_conf.level"
   )
   expect_error(
     tidy(res, conf.int = TRUE, conf.level = c(0.9, 0.95)),
-    class = "propensity_conf_level_error"
+    class = "causalgenerics_invalid_argument_conf.level"
   )
   expect_error(
     tidy(res, conf.int = TRUE, conf.level = NA_real_),
-    class = "propensity_conf_level_error"
+    class = "causalgenerics_invalid_argument_conf.level"
   )
   expect_error(
     tidy(res, conf.int = TRUE, conf.level = NULL),
-    class = "propensity_conf_level_error"
+    class = "causalgenerics_invalid_argument_conf.level"
   )
 
   # The level is validated whether or not bounds were asked for, so a bad value
   # is reported rather than quietly going unused.
   expect_error(
     tidy(res, conf.level = "0.95"),
-    class = "propensity_conf_level_error"
+    class = "causalgenerics_invalid_argument_conf.level"
+  )
+})
+
+test_that("tidy() rejects the argument values the coercion surface refuses", {
+  skip_if_not_installed("deli")
+  dat <- sim_tidy_binary()
+  mods <- fit_tidy_binary_models(dat)
+  res <- ipw(mods$ps_mod, mods$outcome_mod, se_method = "mestimation")
+
+  # The three arguments `tidy()` shares with the result's own coercion surface
+  # are refused there under a class naming the argument, and the marginal
+  # reading takes them to that surface. The conditional reading answers from
+  # the accessors instead, so it validates them itself, and it has to reach the
+  # same conditions: one argument of one method cannot be well formed in one
+  # reading of a result and not in the other.
+  readings <- list(
+    marginal = res,
+    conditional = as_conditional(res)
+  )
+
+  for (reading in readings) {
+    expect_error(
+      tidy(reading, conf.int = NA),
+      class = "causalgenerics_invalid_argument_conf.int"
+    )
+    expect_error(
+      tidy(reading, conf.int = c(TRUE, TRUE)),
+      class = "causalgenerics_invalid_argument_conf.int"
+    )
+    expect_error(
+      tidy(reading, exponentiate = NA),
+      class = "causalgenerics_invalid_argument_exponentiate"
+    )
+    expect_error(
+      tidy(reading, exponentiate = "yes"),
+      class = "causalgenerics_invalid_argument_exponentiate"
+    )
+    expect_error(
+      tidy(reading, conf.level = 95),
+      class = "causalgenerics_invalid_argument_conf.level"
+    )
+    expect_error(
+      tidy(reading, conf.int = TRUE, conf.level = 95),
+      class = "causalgenerics_invalid_argument_conf.level"
+    )
+  }
+
+  # Naming the reading at the call site reaches the same refusals as recording
+  # it does, the value being refused before either reading is assembled.
+  expect_error(
+    tidy(res, conf.int = NA, effects = "conditional"),
+    class = "causalgenerics_invalid_argument_conf.int"
+  )
+  expect_error(
+    tidy(res, exponentiate = NA, effects = "conditional"),
+    class = "causalgenerics_invalid_argument_exponentiate"
+  )
+  expect_error(
+    tidy(res, conf.level = 95, effects = "conditional"),
+    class = "causalgenerics_invalid_argument_conf.level"
+  )
+  expect_error(
+    tidy(as_conditional(res), conf.int = NA, effects = "marginal"),
+    class = "causalgenerics_invalid_argument_conf.int"
   )
 })
 
@@ -814,17 +983,19 @@ test_that("tidy(exponentiate = TRUE) matches as.data.frame on a binary fit", {
   res <- ipw(mods$ps_mod, mods$outcome_mod, se_method = "mestimation")
 
   # `exponentiate` is documented as behaving exactly as it does in
-  # `as.data.frame.ipw`, so the two surfaces must agree column for column.
-  df <- as.data.frame(res, exponentiate = TRUE)
+  # `as.data.frame.ipw`, so the two surfaces must agree column for column. The
+  # bounds are a column of that frame only when it was asked for them, which is
+  # the same rule the tidier follows.
+  df <- as.data.frame(res, conf.int = TRUE, exponentiate = TRUE)
   tidied <- tidy(res, conf.int = TRUE, exponentiate = TRUE)
 
-  expect_identical(tidied$term, df$effect)
+  expect_identical(tidied$term, df$term)
   expect_identical(tidied$estimate, df$estimate)
-  expect_identical(tidied$std.error, df$std.err)
-  expect_identical(tidied$statistic, df$z)
+  expect_identical(tidied$std.error, df$std.error)
+  expect_identical(tidied$statistic, df$statistic)
   expect_identical(tidied$p.value, df$p.value)
-  expect_identical(tidied$conf.low, df$ci.lower)
-  expect_identical(tidied$conf.high, df$ci.upper)
+  expect_identical(tidied$conf.low, df$conf.low)
+  expect_identical(tidied$conf.high, df$conf.high)
 })
 
 test_that("tidy(exponentiate = TRUE) relabels ratio rows per comparison", {
@@ -834,16 +1005,16 @@ test_that("tidy(exponentiate = TRUE) relabels ratio rows per comparison", {
   mods <- fit_tidy_categorical_models(dat)
   res <- ipw(mods$ps_mod, mods$outcome_mod)
 
-  df <- as.data.frame(res, exponentiate = TRUE)
+  df <- as.data.frame(res, conf.int = TRUE, exponentiate = TRUE)
   tidied <- tidy(res, conf.int = TRUE, exponentiate = TRUE)
 
   expect_identical(tidied$term, rep(c("rd", "rr", "or"), times = 2))
   expect_identical(tidied$comparison, rep(c("b vs a", "c vs a"), each = 3))
-  expect_identical(tidied$term, df$effect)
+  expect_identical(tidied$term, df$term)
   expect_identical(tidied$comparison, df$comparison)
   expect_identical(tidied$estimate, df$estimate)
-  expect_identical(tidied$conf.low, df$ci.lower)
-  expect_identical(tidied$conf.high, df$ci.upper)
+  expect_identical(tidied$conf.low, df$conf.low)
+  expect_identical(tidied$conf.high, df$conf.high)
 })
 
 test_that("tidy(exponentiate = TRUE) relabels the continuous log odds ratio", {
@@ -1890,7 +2061,7 @@ test_that("tidy() rebuilds the conditional interval at the level asked for", {
   )
   expect_error(
     tidy(res, conf.int = TRUE, conf.level = 1, effects = "conditional"),
-    class = "propensity_conf_level_error"
+    class = "causalgenerics_invalid_argument_conf.level"
   )
 })
 

--- a/tests/testthat/test-ipw-tidiers.R
+++ b/tests/testthat/test-ipw-tidiers.R
@@ -181,12 +181,19 @@ fit_tidy_continuous_models <- function(dat, outcome_family = "gaussian") {
 # the same count and different rows. The weights come from a propensity score
 # model of the complete data, which gives the outcome model a weight for every
 # row it keeps whichever rows those are.
+#
+# The exposure is made to alternate rather than left as the simulated draw.
+# Dropping one row from a frame shifts every row after it up by one, so a
+# sequence that alternates disagrees with itself at every shifted position,
+# which is what makes two frames of different rows provably different rather
+# than different only if the draw happened not to repeat itself across the gap.
 fit_tidy_misaligned_models <- function(
   dat,
   ps_row = integer(),
   outcome_row = integer()
 ) {
   withr::local_seed(825)
+  dat$z <- rep(c(0L, 1L), length.out = nrow(dat))
   dat$xp <- rnorm(nrow(dat))
   dat$xo <- rnorm(nrow(dat))
   dat$xp[ps_row] <- NA
@@ -202,6 +209,85 @@ fit_tidy_misaligned_models <- function(
     outcome_mod = glm(
       y ~ z + xo,
       data = dat,
+      family = quasibinomial(),
+      weights = wts
+    )
+  )
+}
+
+# A pair of models fit to frames whose rows were renumbered from 1, which is what
+# a frame arrives with when the rows missing a value were dropped before either
+# model was fit rather than by the models themselves. `drop_row` names the row
+# each model's frame is missing, so the two frames carry the same row labels
+# whether or not they hold the same observations: equal labels for equal rows
+# when the two arguments agree, and equal labels for different rows when they do
+# not. The exposure alternates for the reason the fixture above sets it to.
+#
+# `ps_factor` holds the exposure of the propensity score model's data as a factor
+# of the labels `"0"` and `"1"`, leaving the two frames recording one exposure in
+# two encodings, as a fit of a factor exposure against an outcome model of the
+# numbers behind it does.
+fit_tidy_renumbered_models <- function(
+  dat,
+  ps_drop,
+  outcome_drop,
+  ps_factor = FALSE
+) {
+  dat$z <- rep(c(0L, 1L), length.out = nrow(dat))
+
+  renumber <- function(rows) {
+    frame <- dat[-rows, ]
+    rownames(frame) <- NULL
+    frame
+  }
+  ps_data <- renumber(ps_drop)
+  outcome_data <- renumber(outcome_drop)
+
+  if (ps_factor) {
+    ps_data$z <- factor(ps_data$z)
+  }
+
+  wts <- withr::with_options(
+    list(propensity.quiet = TRUE),
+    wt_ate(glm(z ~ x1 + x2, data = outcome_data, family = binomial()))
+  )
+
+  list(
+    ps_mod = glm(z ~ x1 + x2, data = ps_data, family = binomial()),
+    outcome_mod = glm(
+      y ~ z,
+      data = outcome_data,
+      family = quasibinomial(),
+      weights = wts
+    )
+  )
+}
+
+# A pair of models describing the same rows in the same order under different row
+# labels. The propensity score model is fit to the frame holding the missing
+# values and drops those rows itself, which leaves its frame labeled around the
+# gaps; the outcome model is fit to the same rows with their labels renumbered
+# from 1, as a frame filtered before fitting arrives. This is the shape of an
+# analysis that dropped incomplete rows in the pipeline rather than in the
+# models, and there is nothing wrong with it.
+fit_tidy_relabeled_models <- function(dat, na_rows) {
+  withr::local_seed(825)
+  dat$xp <- rnorm(nrow(dat))
+  dat$xp[na_rows] <- NA
+
+  complete <- dat[!is.na(dat$xp), ]
+  rownames(complete) <- NULL
+
+  wts <- withr::with_options(
+    list(propensity.quiet = TRUE),
+    wt_ate(glm(z ~ x1 + x2, data = complete, family = binomial()))
+  )
+
+  list(
+    ps_mod = glm(z ~ x1 + xp, data = dat, family = binomial()),
+    outcome_mod = glm(
+      y ~ z,
+      data = complete,
       family = quasibinomial(),
       weights = wts
     )
@@ -1286,6 +1372,9 @@ test_that("augment(data = ) rejects data holding a column augment adds", {
     augment(res, data = collide),
     class = "propensity_augment_column_error"
   )
+
+  # the refusal names the column in the way and what to do about it
+  expect_propensity_error(augment(res, data = collide))
 })
 
 test_that("augment(data = ) names every column of the data it clashes with", {
@@ -1311,6 +1400,9 @@ test_that("augment(data = ) names every column of the data it clashes with", {
   expect_match(msg, ".propensity", fixed = TRUE)
   expect_match(msg, ".weights", fixed = TRUE)
   expect_match(msg, ".fitted", fixed = TRUE)
+
+  # the sentence the three names are reported in
+  expect_propensity_error(augment(res, data = collide))
 })
 
 test_that("augment(data = ) counts a .resid column only when it adds one", {
@@ -1360,6 +1452,9 @@ test_that("augment(data = ) clashes on the level columns of a categorical fit", 
     augment(res, data = collide),
     class = "propensity_augment_column_error"
   )
+
+  # the refusal names the level column rather than `.propensity`
+  expect_propensity_error(augment(res, data = collide))
 
   # `.propensity` is not one of them on this route. No column of that name is
   # added, so a column of the caller's carrying it is theirs to keep, which is
@@ -1421,6 +1516,9 @@ test_that("augment() rejects a result whose models saw different counts", {
   msg <- gsub("[[:space:]]+", " ", conditionMessage(err))
   expect_match(msg, "\\b599\\b")
   expect_match(msg, "\\b600\\b")
+
+  # the sentence the two counts are reported in
+  expect_propensity_error(augment(res))
 })
 
 test_that("augment() rejects a result whose models saw different rows", {
@@ -1429,17 +1527,170 @@ test_that("augment() rejects a result whose models saw different rows", {
   res <- new_tidy_ipw(mods$ps_mod, mods$outcome_mod)
 
   # Each model dropped one row and they dropped different ones, so the counts
-  # agree and the rows do not. A count is all that a column of the right length
-  # proves; the row names the two models kept are what says whether the
-  # observation in a row of one is the observation in that row of the other.
-  ps_rows <- names(stats::predict(mods$ps_mod, type = "response"))
-  outcome_rows <- rownames(stats::model.frame(mods$outcome_mod))
-  expect_identical(length(ps_rows), length(outcome_rows))
-  expect_false(identical(ps_rows, outcome_rows))
+  # agree and the observations do not. A count is all that a column of the right
+  # length proves; what says whether the observation in a row of one frame is
+  # the observation in that row of the other is the data, and the exposure is
+  # the variable both frames hold.
+  ps_frame <- stats::model.frame(mods$ps_mod)
+  outcome_frame <- stats::model.frame(mods$outcome_mod)
+  expect_identical(nrow(ps_frame), nrow(outcome_frame))
+  expect_false(identical(ps_frame$z, outcome_frame$z))
 
   expect_error(
     augment(res),
     class = "propensity_augment_alignment_error"
+  )
+
+  # the refusal reports observations that agree in number and not in identity
+  expect_propensity_error(augment(res))
+})
+
+test_that("augment() rejects models of different rows carrying equal labels", {
+  dat <- sim_tidy_binary()
+  mods <- fit_tidy_renumbered_models(dat, ps_drop = 7, outcome_drop = 12)
+  res <- new_tidy_ipw(mods$ps_mod, mods$outcome_mod)
+
+  # Both frames were renumbered from 1 before either model was fit, so the two
+  # carry exactly the same row labels while holding different observations. A
+  # label records where a row came from and survives nothing that renumbers it,
+  # so agreeing labels are no evidence of agreeing rows and this fit has to be
+  # caught by the data itself.
+  ps_frame <- stats::model.frame(mods$ps_mod)
+  outcome_frame <- stats::model.frame(mods$outcome_mod)
+  expect_identical(rownames(ps_frame), rownames(outcome_frame))
+  expect_identical(rownames(outcome_frame), as.character(1:599))
+  expect_false(identical(ps_frame$z, outcome_frame$z))
+
+  expect_error(
+    augment(res),
+    class = "propensity_augment_alignment_error"
+  )
+})
+
+test_that("augment() carries a factor exposure against its numeric encoding", {
+  skip_if_not_installed("deli")
+  dat <- sim_tidy_binary()
+  factor_dat <- dat
+  factor_dat$z <- factor(dat$z)
+
+  # The propensity score model was fit to the exposure as a factor and the
+  # outcome model to the 0/1 numbers those labels spell, which is a pair
+  # `ipw()` builds a result from. The two frames record one exposure in two
+  # encodings and describe the same rows, so the columns read from either belong
+  # beside the columns read from the other, and a comparison that read `"0"`
+  # against 0 as a disagreement would refuse a fit with nothing wrong with it.
+  ps_mod <- glm(z ~ x1 + x2, data = factor_dat, family = binomial())
+  wts <- withr::with_options(list(propensity.quiet = TRUE), wt_ate(ps_mod))
+  outcome_mod <- glm(
+    y ~ z,
+    data = dat,
+    family = quasibinomial(),
+    weights = wts,
+    control = glm.control(epsilon = 1e-14, maxit = 200)
+  )
+  res <- ipw(ps_mod, outcome_mod)
+
+  augmented <- augment(res)
+  expect_augment_contract(augmented, augment_source_frame(outcome_mod), res)
+
+  # The encoding of the exposure the propensity score model was fit to is not
+  # something the reported columns depend on, so the frame is the one the same
+  # fit of the numeric exposure returns, column for column.
+  numeric_mods <- fit_tidy_binary_models(dat)
+  numeric_res <- ipw(numeric_mods$ps_mod, numeric_mods$outcome_mod)
+  expect_identical(augmented, augment(numeric_res))
+})
+
+test_that("augment() carries an exposure recoded past what a number reads", {
+  skip_if_not_installed("deli")
+  dat <- sim_tidy_binary()
+  labeled <- dat
+  labeled$z <- factor(ifelse(dat$z == 1, "b", "a"), levels = c("a", "b"))
+
+  # Here the two encodings are a factor of `"a"` and `"b"` against the 0 and 1 a
+  # user recoded it to. The labels spell no numbers, so nothing lines the two up
+  # position by position: their values differ at every position while their
+  # observations agree at all of them. A comparison that cannot tell those apart
+  # has proven nothing, and proving nothing is not a reason to refuse.
+  ps_mod <- glm(z ~ x1 + x2, data = labeled, family = binomial())
+  ps_labels <- as.character(stats::model.frame(ps_mod)$z)
+  expect_true(anyNA(suppressWarnings(as.numeric(ps_labels))))
+
+  wts <- withr::with_options(list(propensity.quiet = TRUE), wt_ate(ps_mod))
+  outcome_mod <- glm(
+    y ~ z,
+    data = dat,
+    family = quasibinomial(),
+    weights = wts,
+    control = glm.control(epsilon = 1e-14, maxit = 200)
+  )
+  res <- ipw(ps_mod, outcome_mod)
+
+  augmented <- augment(res)
+  expect_augment_contract(augmented, augment_source_frame(outcome_mod), res)
+  expect_identical(
+    augmented$.propensity,
+    unname(stats::predict(ps_mod, type = "response"))
+  )
+})
+
+test_that("augment() rejects a factor exposure of rows the numbers deny", {
+  dat <- sim_tidy_binary()
+  mods <- fit_tidy_renumbered_models(
+    dat,
+    ps_drop = 7,
+    outcome_drop = 12,
+    ps_factor = TRUE
+  )
+  res <- new_tidy_ipw(mods$ps_mod, mods$outcome_mod)
+
+  # The same two encodings as the fit above, over rows that are not the same
+  # rows. Reading the labels as the numbers they spell is what makes the two
+  # frames comparable, and once they are comparable the alternating exposure
+  # shows the shift between them. An encoding the values can be read through is
+  # no reason to stop looking at the values.
+  ps_frame <- stats::model.frame(mods$ps_mod)
+  outcome_frame <- stats::model.frame(mods$outcome_mod)
+  expect_s3_class(ps_frame$z, "factor")
+  expect_identical(rownames(ps_frame), rownames(outcome_frame))
+  expect_false(identical(
+    as.numeric(as.character(ps_frame$z)),
+    as.numeric(outcome_frame$z)
+  ))
+
+  expect_error(
+    augment(res),
+    class = "propensity_augment_alignment_error"
+  )
+})
+
+test_that("augment() carries models of the same rows carrying different labels", {
+  dat <- sim_tidy_binary()
+  mods <- fit_tidy_relabeled_models(dat, na_rows = c(7, 12, 400))
+  res <- new_tidy_ipw(mods$ps_mod, mods$outcome_mod)
+
+  # The propensity score model dropped the three incomplete rows itself and is
+  # labeled around the gaps; the outcome model was fit to the same rows after
+  # they had been renumbered from 1. The two describe the same 597 observations
+  # in the same order, which is what makes the columns of one belong beside the
+  # columns of the other, and their labels disagree throughout, which is nothing.
+  ps_frame <- stats::model.frame(mods$ps_mod)
+  outcome_frame <- stats::model.frame(mods$outcome_mod)
+  expect_identical(nrow(ps_frame), 597L)
+  expect_identical(rownames(outcome_frame), as.character(1:597))
+  expect_false(identical(rownames(ps_frame), rownames(outcome_frame)))
+  expect_identical(ps_frame$z, outcome_frame$z)
+
+  augmented <- augment(res)
+  expect_augment_contract(
+    augmented,
+    augment_source_frame(mods$outcome_mod),
+    res
+  )
+  expect_identical(nrow(augmented), 597L)
+  expect_identical(
+    augmented$.propensity,
+    unname(stats::predict(mods$ps_mod, type = "response"))
   )
 })
 
@@ -1493,6 +1744,9 @@ test_that("augment() rejects a result whose outcome model has no weights", {
     augment(res),
     class = "propensity_ipw_weights_missing_error"
   )
+
+  # the refusal says what an ipw() outcome model is fit with
+  expect_propensity_error(augment(res))
 })
 
 # ---- the presentation mode ---------------------------------------------------

--- a/tests/testthat/test-ipw.R
+++ b/tests/testthat/test-ipw.R
@@ -317,16 +317,16 @@ test_that("exponentiate=TRUE in as.data.frame.ipw transforms log(rr), log(or)", 
   df_exp <- as.data.frame(ipw_res, exponentiate = TRUE)
 
   # The log scale has "log(rr)", "log(or)"
-  expect_true(any(df_log$effect == "log(rr)"))
-  expect_true(any(df_log$effect == "log(or)"))
+  expect_true(any(df_log$term == "log(rr)"))
+  expect_true(any(df_log$term == "log(or)"))
 
   # Exponentiated scale => "rr", "or"
-  expect_true(any(df_exp$effect == "rr"))
-  expect_true(any(df_exp$effect == "or"))
+  expect_true(any(df_exp$term == "rr"))
+  expect_true(any(df_exp$term == "or"))
 
   # "rd" should remain the same in both
-  rd_log <- df_log[df_log$effect == "rd", "estimate"]
-  rd_exp <- df_exp[df_exp$effect == "rd", "estimate"]
+  rd_log <- df_log[df_log$term == "rd", "estimate"]
+  rd_exp <- df_exp[df_exp$term == "rd", "estimate"]
   expect_equal(rd_log, rd_exp)
 })
 

--- a/tests/testthat/test-reexports.R
+++ b/tests/testthat/test-reexports.R
@@ -32,3 +32,25 @@ test_that("the exported mode generics are the ones causalgenerics owns", {
   expect_identical(propensity::as_marginal, causalgenerics::as_marginal)
   expect_identical(propensity::as_conditional, causalgenerics::as_conditional)
 })
+
+# `ipw()` is the generic an estimating package supplies a method for, and
+# `estimand()`, `estimand<-`, and `is_causal_wt()` read and set what the weights
+# record about themselves. All four belong to causalgenerics, which owns the
+# result class and the weight contract they describe. Re-exporting them is what
+# lets a user who has loaded only propensity call `ipw()` on their models and
+# reach the same generic another package building on those classes dispatches
+# from.
+
+test_that("propensity exports the shared causal generics", {
+  expect_contains(
+    getNamespaceExports("propensity"),
+    c("ipw", "estimand", "estimand<-", "is_causal_wt")
+  )
+})
+
+test_that("the exported causal generics are the ones causalgenerics owns", {
+  expect_identical(propensity::ipw, causalgenerics::ipw)
+  expect_identical(propensity::estimand, causalgenerics::estimand)
+  expect_identical(propensity::`estimand<-`, causalgenerics::`estimand<-`)
+  expect_identical(propensity::is_causal_wt, causalgenerics::is_causal_wt)
+})


### PR DESCRIPTION
- **Add failing tests for augment refusing mismatched models, clashing columns, and unweighted fits**
- **Refuse to augment a misaligned fit, a clashing frame, or an unweighted outcome model**
- **Pin the stabilization parameter and the re-exported causal generics**
- **Document the estimand averaged predictions target and what the conditional reading requires**
- **Re-pin the tidy and as.data.frame surfaces against the reworked upstream frame**
- **Report the marginal tidy reading as the result's own coercion surface**
